### PR TITLE
Add local demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can also use the included Vagrant box to run locally.
   vagrant up
 ```
 
-Once it completed, visit [http://localhost:8090/](http://localhost:8090/)
+Once `vagrant up` completes, visit [visit http://localhost:8090/DASH-IF-Conformance/Conformance-Frontend/index.html](visit http://localhost:8090/DASH-IF-Conformance/Conformance-Frontend/index.html)
 
 ** Refer to https://www.vagrantup.com/ for Vagrant installation and usage documentation.  
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ To clone the IntegratedConformance with all the submodules, use the command,
 
 git clone --recurse-submodules https://github.com/Dash-Industry-Forum/DASH-IF-Conformance
 
+You can also use the included Vagrant box to run locally.
+
+```
+  cd DASH-IF-Conformance/vagrant/
+  vagrant up
+```
+
+Once it completed, visit [http://localhost:8090/](http://localhost:8090/)
+
+** Refer to https://www.vagrantup.com/ for Vagrant installation and usage documentation.  
+
 ### Usage Guide
 
 Information on how to use the conformance software, please refer to our [Usage Guide](https://github.com/Dash-Industry-Forum/DASH-IF-Conformance/blob/master/Doc/Conformance%20Software%20Usage%20Guide.pdf) document.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can also use the included Vagrant box to run locally.
   vagrant up
 ```
 
-Once `vagrant up` completes, visit [visit http://localhost:8090/DASH-IF-Conformance/Conformance-Frontend/index.html](visit http://localhost:8090/DASH-IF-Conformance/Conformance-Frontend/index.html)
+Once `vagrant up` completes, visit [visit http://localhost:8090/DASH-IF-Conformance/Conformance-Frontend/index.html](http://localhost:8090/DASH-IF-Conformance/Conformance-Frontend/index.html)
 
 ** Refer to https://www.vagrantup.com/ for Vagrant installation and usage documentation.  
 

--- a/vagrant/.gitignore
+++ b/vagrant/.gitignore
@@ -1,0 +1,1 @@
+.vagrant/

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,14 @@
+Vagrant.configure("2") do |config|
+    config.vm.box = "bento/ubuntu-16.04"
+    
+    config.vm.provider "virtualbox" do |v|
+      v.name = "DASH-IF-Conformance"
+    end
+    
+    config.vm.network "forwarded_port", guest: 8090, host: 8090
+    config.vm.provision :shell, path: "provision.sh"
+    config.vm.synced_folder ".", "/vagrant", disabled: true
+    config.vm.synced_folder "../", "/vagrant"
+    
+end
+

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -40,7 +40,6 @@ MAKEFLAGS=-j$MAKE_PARALLEL_JOBS
 
 cd DASH-IF-Conformance/ISOSegmentValidator/public/linux/
 make $MAKEFLAGS
-make install
 
 chmod -R 0777 /var/www/
 

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -11,7 +11,8 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y php php-dev php-xml php-curl php-xdebug libapache2-mod-php \
                    default-jdk apache2 apache2-doc python2.7 python-pip \
-                   python-matplotlib ant git libstdc++6:i386
+                   python-matplotlib ant git libstdc++6:i386 gcc-multilib \
+                   g++-multilib
 
 
 java -version

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -50,4 +50,4 @@ echo '' >>  /etc/apache2/sites-available/000-dash.conf
 a2ensite 000-dash
 service apache2 reload
 
-echo "Success! Use your browser to visit http://localhost:8090/"
+echo "Success! Use your browser to visit http://localhost:8090/DASH-IF-Conformance/Conformance-Frontend/index.html"

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -50,4 +50,4 @@ echo '' >>  /etc/apache2/sites-available/000-dash.conf
 a2ensite 000-dash
 service apache2 reload
 
-echo "Success! Use your browser to visit http://localhost:8090/DASH-IF-Conformance/Conformance-Frontend/index.html"
+echo "Success! Use your browser to visit http://localhost:8090/"

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -41,7 +41,7 @@ echo '' >  /etc/apache2/sites-available/000-dash.conf
 echo 'Listen 8090' >>  /etc/apache2/sites-available/000-dash.conf
 echo '<VirtualHost *:8090>' >>  /etc/apache2/sites-available/000-dash.conf
 echo '        ServerAdmin webmaster@localhost' >>  /etc/apache2/sites-available/000-dash.conf
-echo '        DocumentRoot /var/www/DASH-IF-Conformance/Conformance-Frontend' >>  /etc/apache2/sites-available/000-dash.conf
+echo '        DocumentRoot /var/www' >>  /etc/apache2/sites-available/000-dash.conf
 echo '        ErrorLog ${APACHE_LOG_DIR}/error.log' >>  /etc/apache2/sites-available/000-dash.conf
 echo '        CustomLog ${APACHE_LOG_DIR}/access.log combined' >>  /etc/apache2/sites-available/000-dash.conf
 echo '</VirtualHost>' >>  /etc/apache2/sites-available/000-dash.conf

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -11,7 +11,7 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y php php-dev php-xml php-curl php-xdebug libapache2-mod-php \
                    default-jdk apache2 apache2-doc python2.7 python-pip \
-                   python-matplotlib ant git
+                   python-matplotlib ant git libstdc++6:i386
 
 
 java -version
@@ -33,6 +33,13 @@ usermod -a -G www-data vagrant
 cd /var/www
 
 git clone --recurse-submodules https://github.com/Dash-Industry-Forum/DASH-IF-Conformance
+
+MAKE_PARALLEL_JOBS=10
+MAKEFLAGS=-j$MAKE_PARALLEL_JOBS
+
+cd DASH-IF-Conformance/ISOSegmentValidator/public/linux/
+make $MAKEFLAGS
+make install
 
 chmod -R 0777 /var/www/
 

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -1,0 +1,53 @@
+set -o errexit
+set -o pipefail
+set -o nounset
+shopt -s failglob
+set -o xtrace
+
+export DEBIAN_FRONTEND=noninteractive
+
+# ref https://github.com/Dash-Industry-Forum/DASH-IF-Conformance/blob/master/Doc/Conformance%20Software%20Installation%20Guide.pdf
+
+apt-get update
+apt-get install -y php php-dev php-xml php-curl php-xdebug libapache2-mod-php \
+                   default-jdk apache2 apache2-doc python2.7 python-pip \
+                   python-matplotlib ant git
+
+
+java -version
+javac -version
+
+
+echo '' >  /etc/sudoers.d/dash
+echo '# the conformance software requires sudo permission to run' >>  /etc/sudoers.d/dash
+echo '%www-data ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/dash
+echo '' >>  /etc/sudoers.d/dash
+chmod 0440 /etc/sudoers.d/dash
+cat /etc/sudoers.d/dash
+
+
+service apache2 restart
+
+usermod -a -G www-data vagrant
+
+cd /var/www
+
+git clone --recurse-submodules https://github.com/Dash-Industry-Forum/DASH-IF-Conformance
+
+chmod -R 0777 /var/www/
+
+
+echo '' >  /etc/apache2/sites-available/000-dash.conf
+echo 'Listen 8090' >>  /etc/apache2/sites-available/000-dash.conf
+echo '<VirtualHost *:8090>' >>  /etc/apache2/sites-available/000-dash.conf
+echo '        ServerAdmin webmaster@localhost' >>  /etc/apache2/sites-available/000-dash.conf
+echo '        DocumentRoot /var/www/DASH-IF-Conformance/Conformance-Frontend' >>  /etc/apache2/sites-available/000-dash.conf
+echo '        ErrorLog ${APACHE_LOG_DIR}/error.log' >>  /etc/apache2/sites-available/000-dash.conf
+echo '        CustomLog ${APACHE_LOG_DIR}/access.log combined' >>  /etc/apache2/sites-available/000-dash.conf
+echo '</VirtualHost>' >>  /etc/apache2/sites-available/000-dash.conf
+echo '' >>  /etc/apache2/sites-available/000-dash.conf
+
+a2ensite 000-dash
+service apache2 reload
+
+echo "Success! Use your browser to visit http://localhost:8090/DASH-IF-Conformance/Conformance-Frontend/index.html"


### PR DESCRIPTION
The installation docs are correct, but make it seem much more complicated to install the validator than it is.

I've added vagrant to the repo.  This makes the demo usable with one command from the user.

I.e. run `vagrant up` from the vagrant subfolder and then you have a working demo for validating your DASH manifests.