### PR TITLE
Support running in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:16.04
+
+EXPOSE 80
+
+RUN apt update
+RUN apt -y install apache2 apache2-doc php php-dev php-xml php-curl php-xdebug libapache2-mod-php
+RUN apt -y install python2.7 python-pip python-matplotlib
+RUN apt -y install openjdk-8-jdk ant
+
+CMD apachectl -D FOREGROUND

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,19 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
+ENV TZ=Etc/GMT
+ENV DEBIAN_FRONTEND=noninteractive
 
 EXPOSE 80
 
 RUN apt update
-RUN apt -y install apache2 apache2-doc php php-dev php-xml php-curl php-xdebug libapache2-mod-php
-RUN apt -y install python2.7 python-pip python-matplotlib
-RUN apt -y install openjdk-8-jdk ant
+RUN apt -y install \
+  apache2 apache2-doc php php-dev php-xml php-curl php-xdebug libapache2-mod-php \
+  python2.7 \
+  openjdk-8-jdk ant
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
+RUN python2.7 get-pip.py
+RUN pip2 install matplotlib
+RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+
+COPY --chown=www-data:www-data . /var/www/html/
 
 CMD apachectl -D FOREGROUND

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # DASH-IF Conformance Software
 
-This repository provides the source code for MPEG-DASH/DASH-IF Conformance Software/Validator. It has been extended according to further standards, such as CMAF, DVB-DASH, HbbTV, and CTA WAVE. 
+This repository provides the source code for MPEG-DASH/DASH-IF Conformance Software/Validator. It has been extended according to further standards, such as CMAF, DVB-DASH, HbbTV, and CTA WAVE.
 
-This repository contains the common directory (Utils) and submodules: 
+This repository contains the common directory (Utils) and submodules:
 * [DASH](https://github.com/Dash-Industry-Forum/DASH)
 * [HLS](https://github.com/Dash-Industry-Forum/HLS)
-* [CMAF](https://github.com/Dash-Industry-Forum/CMAF) 
+* [CMAF](https://github.com/Dash-Industry-Forum/CMAF)
 * [CTAWAVE](https://github.com/Dash-Industry-Forum/CTAWAVE)
-* [HbbTV_DVB](https://github.com/Dash-Industry-Forum/HbbTV_DVB) 
+* [HbbTV_DVB](https://github.com/Dash-Industry-Forum/HbbTV_DVB)
 * [ISOSegmentValidator](https://github.com/Dash-Industry-Forum/ISOSegmentValidator)
 * [Conformance-Frontend](https://github.com/Dash-Industry-Forum/Conformance-Frontend)
 * [Conformance-Frontend-HLS](https://github.com/Dash-Industry-Forum/Conformance-Frontend-HLS)
@@ -17,9 +17,9 @@ Each submodule is a repository on its own with its respective functionalities an
 
 ### Installation
 
-For the complete installation including dependencies etc, please refer [Installation guide]( https://github.com/Dash-Industry-Forum/DASH-IF-Conformance/blob/master/Doc/Conformance%20Software%20Installation%20Guide.pdf).
+For the complete installation including dependencies etc, please refer to [Installation guide]( https://github.com/Dash-Industry-Forum/DASH-IF-Conformance/wiki/Installation--guide).
 
-To clone the IntegratedConformance with all the submodules, use the command, 
+To clone the IntegratedConformance with all the submodules, use the command,
 
 git clone --recurse-submodules https://github.com/Dash-Industry-Forum/DASH-IF-Conformance
 
@@ -37,9 +37,9 @@ If the issue is known to correspond to a specific submodule functionality, pleas
 
 * [DASH issues](https://github.com/Dash-Industry-Forum/DASH/issues)
 * [HLS issues](https://github.com/Dash-Industry-Forum/HLS/issues)
-* [CMAF issues](https://github.com/Dash-Industry-Forum/CMAF/issues) 
+* [CMAF issues](https://github.com/Dash-Industry-Forum/CMAF/issues)
 * [CTAWAVE issues](https://github.com/Dash-Industry-Forum/CTAWAVE/issues)
-* [HbbTV_DVB issues](https://github.com/Dash-Industry-Forum/HbbTV_DVB/issues) 
+* [HbbTV_DVB issues](https://github.com/Dash-Industry-Forum/HbbTV_DVB/issues)
 * [ISOSegmentValidator issues](https://github.com/Dash-Industry-Forum/ISOSegmentValidator/issues)
 * [Conformance-Frontend issues](https://github.com/Dash-Industry-Forum/Conformance-Frontend/issues)
 * [Conformance-Frontend-HLS issues](https://github.com/Dash-Industry-Forum/Conformance-Frontend-HLS/issues)

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#/bin/sh
+
+docker build -t dash-if-conformance:latest -t dash-if-conformance:$(git rev-parse --short HEAD) .


### PR DESCRIPTION
Add support to run entire stack in docker, draft PR

Use `./build.sh` to locally build your docker image with all dependencies.

Create and run container from repository root directory, e.g.: `docker run -d --name dc-tester -p 80:80 -v `pwd`:/var/www/html dash-if-conformance`.