### PR TITLE
Remove erroneous test R1.4

### DIFF
--- a/DASH/mpdvalidator/schematron/schematron.sch
+++ b/DASH/mpdvalidator/schematron/schematron.sch
@@ -20,8 +20,6 @@
 			<assert test="if (@type = 'dynamic' and not(@publishTime)) then false() else true()">If MPD is of type "dynamic" publishTime shall be defined.</assert>
 			<!-- R1.3 -->
 			<!-- <assert test="if (@type = 'static' and not(@mediaPresentationDuration)) then false() else true()">If MPD is of type "static" mediaPresentationDuration shall be defined.</assert>  -->
-			<!-- R1.4 -->
-			<assert test="if (@type = 'static' and descendant::dash:Period[1]/@start and (years-from-duration(descendant::dash:Period[1]/@start) + months-from-duration(descendant::dash:Period[1]/@start) + days-from-duration(descendant::dash:Period[1]/@start) + hours-from-duration(descendant::dash:Period[1]/@start) + minutes-from-duration(descendant::dash:Period[1]/@start) +  seconds-from-duration(descendant::dash:Period[1]/@start)) > 0) then false() else true()">If MPD is of type "static" and the first period has a start attribute the start attribute shall be zero.</assert>
 			<!-- R1.5 -->
 			<assert test="if (not(@mediaPresentationDuration) and not(@minimumUpdatePeriod)) then false() else true()">If mediaPresentationDuration is not defined for the MPD minimumUpdatePeriod shall be defined or vice versa.</assert>
 			<!-- R1.7 -->


### PR DESCRIPTION
R1.4 checks that if the first period has a @start attribute then it is 0. This seems to be a misinterpretation of ISO/IEC 23009-1 (MPEG-DASH).
This fixes #561 .