### PR TITLE
Bugfix/health checks

### DIFF
--- a/CMAF/impl/checkCMAFTracks.php
+++ b/CMAF/impl/checkCMAFTracks.php
@@ -25,7 +25,7 @@ if (!file_exists($xmlRepresentation)) {
 $xml = get_DOM($xmlRepresentation, 'atomlist');
 
 if (!$xml) {
-    fwrite(STDERR, "NO xml in $xmlRepresentation\n");
+    fwrite(STDERR, "Invalid xml in $xmlRepresentation\n");
     return;
 }
 

--- a/CTAWAVE/impl/CTACheckPresentation.php
+++ b/CTAWAVE/impl/CTACheckPresentation.php
@@ -176,12 +176,10 @@ if (in_array("", $presentationProfileArray)) {
     $presentationProfile = "";
 }
 
-$logger->test(
-    "CTAWAVE",
-    "Informative",
-    "Wave set conformance to CMAF Presentation Profile",
-    $presentationProfile != "",
-    "PASS",
-    "Conformance to $presentationProfile",
-    "No conformance found"
-);
+
+if ($presentationProfile != ""){
+
+}
+
+$logger->message("Stream found to conform to a CMAF Presentation Profile: $presentationProfile");
+

--- a/DASH/processMPD.php
+++ b/DASH/processMPD.php
@@ -108,6 +108,7 @@ function processAdaptationSetOfCurrentPeriod($period, $ResultXML, $segment_urls)
 
     global $modules;
 
+    global $logger;
 
     $adaptation_sets = $period['AdaptationSet'];
     while ($current_adaptation_set < sizeof($adaptation_sets)) {

--- a/DASH/processMPD.php
+++ b/DASH/processMPD.php
@@ -74,7 +74,6 @@ function process_MPD($parseSegments = false)
       return;
     }
     if ($mpd_features['type'] !== 'dynamic') {
-        $mpdHandler->selectPeriod(0);
         $current_period = 0;
     }
     while ($current_period < sizeof($mpd_features['Period'])) {

--- a/DASH/processMPD.php
+++ b/DASH/processMPD.php
@@ -53,7 +53,7 @@ function process_MPD($parseSegments = false)
     ## If only MPD validation is requested or inferred, stop
     ## If any error is found in the MPD validation process, stop
     ## If no error is found, then proceed with segment validation below
-    //$valid_mpd = validate_MPD();
+//    $valid_mpd = validate_MPD();
 
 
 
@@ -64,16 +64,17 @@ function process_MPD($parseSegments = false)
     }
 
     if (!$parseSegments) {
-        fwrite(STDERR,($parseSegments ? "DO " : "DO NOT ") . "parse segments\n");
+        fwrite(STDERR, ($parseSegments ? "DO " : "DO NOT ") . "parse segments\n");
         return;
     }
 
     //------------------------------------------------------------------------//
     ## Perform Segment Validation for each representation in each adaptation set within the current period
     if (!checkBeforeSegmentValidation()) {
-        return;
+      return;
     }
     if ($mpd_features['type'] !== 'dynamic') {
+        $mpdHandler->selectPeriod(0);
         $current_period = 0;
     }
     while ($current_period < sizeof($mpd_features['Period'])) {
@@ -111,6 +112,9 @@ function processAdaptationSetOfCurrentPeriod($period, $ResultXML, $segment_urls)
 
     $adaptation_sets = $period['AdaptationSet'];
     while ($current_adaptation_set < sizeof($adaptation_sets)) {
+        if ($logger->getModuleVerdict("HEALTH") == "FAIL") {
+            break;
+        }
         $adaptation_set = $adaptation_sets[$current_adaptation_set];
         $representations = $adaptation_set['Representation'];
 
@@ -118,6 +122,9 @@ function processAdaptationSetOfCurrentPeriod($period, $ResultXML, $segment_urls)
 
 
         while ($current_representation < sizeof($representations)) {
+            if ($logger->getModuleVerdict("HEALTH") == "FAIL") {
+                break;
+            }
             $representation = $representations[$current_representation];
             $segment_url = $segment_urls[$current_adaptation_set][$current_representation];
 
@@ -131,7 +138,12 @@ function processAdaptationSetOfCurrentPeriod($period, $ResultXML, $segment_urls)
                 }
             }
 
+            $logger->setModule("HEALTH");
             validate_segment($adaptationDirectory, $representationDirectory, $period, $adaptation_set, $representation, $segment_url, $is_subtitle_rep);
+            $logger->write();
+            if ($logger->getModuleVerdict("HEALTH") == "FAIL") {
+                break;
+            }
 
             foreach ($modules as $module) {
                 if ($module->isEnabled()) {
@@ -140,6 +152,9 @@ function processAdaptationSetOfCurrentPeriod($period, $ResultXML, $segment_urls)
             }
 
             $current_representation++;
+        }
+        if ($logger->getModuleVerdict("HEALTH") == "FAIL") {
+            break;
         }
 
         ## Representations in current Adaptation Set finished
@@ -155,10 +170,12 @@ function processAdaptationSetOfCurrentPeriod($period, $ResultXML, $segment_urls)
         $current_adaptation_set++;
     }
 
+    if ($logger->getModuleVerdict("HEALTH") != "FAIL") {
     ## Adaptation Sets in current Period finished
-    foreach ($modules as $module) {
-        if ($module->isEnabled()) {
-            $module->hookAdaptationSet();
+        foreach ($modules as $module) {
+            if ($module->isEnabled()) {
+                $module->hookAdaptationSet();
+            }
         }
     }
     //err_file_op(2);

--- a/Utils/Process_cli.php
+++ b/Utils/Process_cli.php
@@ -28,7 +28,6 @@ $argumentParser = new DASHIF\ArgumentsParser();
 include __DIR__ . '/sessionHandler.php';
 require __DIR__ . '/moduleInterface.php';
 include __DIR__ . '/moduleLogger.php';
-include __DIR__ . '/MPDHandler.php';
 
 include __DIR__ . '/Session.php';         //#Session Functions, No Direct Executable Code
 //#Document loading functions, mostly xml. Some assertion options and error initialization

--- a/Utils/moduleLogger.php
+++ b/Utils/moduleLogger.php
@@ -69,6 +69,13 @@ class ModuleLogger
         $this->currentHook = '';
     }
 
+    public function getModuleVerdict($moduleName){
+        if (!array_key_exists($moduleName, $this->entries)) {
+          return "PASS";
+        }
+        return $this->entries[$moduleName]['verdict'];
+    }
+
     public function setHook($hookName)
     {
         $this->currentHook = $hookName;
@@ -243,7 +250,7 @@ class ModuleLogger
         return false;
     }
 
-    private function write()
+    public function write()
     {
         $this->entries['Stats']['LastWritten'] = date("Y-m-d h:i:s");
         file_put_contents($this->logfile, \json_encode($this->asArray()));

--- a/Utils/segment_validation.php
+++ b/Utils/segment_validation.php
@@ -175,6 +175,7 @@ function analyze_results($returncode, $curr_adapt_dir, $representationDirectory)
 function run_backend($configFile, $representationDirectory = "")
 {
     global $session;
+    global $logger;
 
     $sessionDirectory = $session->getDir();
 
@@ -199,46 +200,46 @@ function run_backend($configFile, $representationDirectory = "")
 
     $moveAtom = true;
 
-$moveAtom &= $logger->test(
-    "Health Checks",
-    "Segment Validation",
-    "ISOSegmentValidator runs successful",
-    $returncode == 0,
-    "FAIL",
-    "Ran succesful on $configFile; took ". ($et - $t) . "seconds",
-    "Issues with $configFile; Returncode $returncode; took " . ($et - $t) . " seconds"
-);
+    $moveAtom &= $logger->test(
+        "Health Checks",
+        "Segment Validation",
+        "ISOSegmentValidator runs successful",
+        $returncode == 0,
+        "FAIL",
+        "Ran succesful on $configFile; took ". ($et - $t) . "seconds",
+        "Issues with $configFile; Returncode $returncode; took " . ($et - $t) . " seconds"
+    );
 
-$moveAtom &= $logger->test(
-    "Health Checks",
-    "Segment Validation",
-    "AtomInfo written",
-    file_exists("$sessionDirectory/atominfo.xml"),
-    "FAIL",
-    "Atominfo for $representationDirectory exists",
-    "Atominfo for $representationDirectory missing"
-);
+    $moveAtom &= $logger->test(
+        "Health Checks",
+        "Segment Validation",
+        "AtomInfo written",
+        file_exists("$sessionDirectory/atominfo.xml"),
+        "FAIL",
+        "Atominfo for $representationDirectory exists",
+        "Atominfo for $representationDirectory missing"
+    );
 
-$xml = get_DOM("$sessionDirectory/atominfo.xml", 'atomlist');
-$moveAtom &= $logger->test(
-    "Health Checks",
-    "Segment Validation",
-    "AtomInfo contains valid xml",
-    $xml !== false,
-    "FAIL",
-    "Atominfo for $representationDirectory has valid xml",
-    "Atominfo for $representationDirectory has invalid xml"
-);
+    $xml = get_DOM("$sessionDirectory/atominfo.xml", 'atomlist');
+    $moveAtom &= $logger->test(
+        "Health Checks",
+        "Segment Validation",
+        "AtomInfo contains valid xml",
+        $xml !== false,
+        "FAIL",
+        "Atominfo for $representationDirectory has valid xml",
+        "Atominfo for $representationDirectory has invalid xml"
+    );
 
-$moveAtom &= $logger->test(
-    "Health Checks",
-    "Segment Validation",
-    "AtomInfo < 100Mb",
-    filesize("$sessionDirectory/atominfo.xml") < (100 * 1024 * 1024),
-    "FAIL",
-    "Atominfo for $representationDirectory < 100Mb",
-    "Atominfo for $representationDirectory is ". filesize("$sessionDirectory/atominfo.xml")
-);
+    $moveAtom &= $logger->test(
+        "Health Checks",
+        "Segment Validation",
+        "AtomInfo < 100Mb",
+        filesize("$sessionDirectory/atominfo.xml") < (100 * 1024 * 1024),
+        "FAIL",
+        "Atominfo for $representationDirectory < 100Mb",
+        "Atominfo for $representationDirectory is ". filesize("$sessionDirectory/atominfo.xml")
+    );
 
 
     if (!$moveAtom){

--- a/Utils/segment_validation.php
+++ b/Utils/segment_validation.php
@@ -178,7 +178,6 @@ function run_backend($configFile, $representationDirectory = "")
 
     $sessionDirectory = $session->getDir();
 
-    fwrite(STDERR, "Going to run segment validator with config file $configFile\n");
 
     ## Select the executable version
     ## Copy segment validation tool to session folder
@@ -188,14 +187,68 @@ function run_backend($configFile, $representationDirectory = "")
     chmod("$sessionDirectory/$validatemp4", 0777);
 
     ## Execute backend conformance software
-    $command = "$sessionDirectory/$validatemp4 -logconsole -atomxml -configfile " . $configFile;
+    $command = "timeout -k 30s 30s $sessionDirectory/$validatemp4 -logconsole -atomxml -configfile " . $configFile;
     $output = [];
     $returncode = 0;
     chdir($sessionDirectory);
-    exec($command, $output, $returncode);
 
-    if ($representationDirectory != "") {
-        rename("$sessionDirectory/atominfo.xml", "$representationDirectory/atomInfo.xml");
+
+    $t = time();
+    exec($command, $output, $returncode);
+    $et = time();
+
+    $moveAtom = true;
+
+$moveAtom &= $logger->test(
+    "Health Checks",
+    "Segment Validation",
+    "ISOSegmentValidator runs successful",
+    $returncode == 0,
+    "FAIL",
+    "Ran succesful on $configFile; took ". ($et - $t) . "seconds",
+    "Issues with $configFile; Returncode $returncode; took " . ($et - $t) . " seconds"
+);
+
+$moveAtom &= $logger->test(
+    "Health Checks",
+    "Segment Validation",
+    "AtomInfo written",
+    file_exists("$sessionDirectory/atominfo.xml"),
+    "FAIL",
+    "Atominfo for $representationDirectory exists",
+    "Atominfo for $representationDirectory missing"
+);
+
+$xml = get_DOM("$sessionDirectory/atominfo.xml", 'atomlist');
+$moveAtom &= $logger->test(
+    "Health Checks",
+    "Segment Validation",
+    "AtomInfo contains valid xml",
+    $xml !== false,
+    "FAIL",
+    "Atominfo for $representationDirectory has valid xml",
+    "Atominfo for $representationDirectory has invalid xml"
+);
+
+$moveAtom &= $logger->test(
+    "Health Checks",
+    "Segment Validation",
+    "AtomInfo < 100Mb",
+    filesize("$sessionDirectory/atominfo.xml") < (100 * 1024 * 1024),
+    "FAIL",
+    "Atominfo for $representationDirectory < 100Mb",
+    "Atominfo for $representationDirectory is ". filesize("$sessionDirectory/atominfo.xml")
+);
+
+
+    if (!$moveAtom){
+      fwrite(STDERR, "Ignoring atomfile for $representationDirectory\n");
+      unlink("$sessionDirectory/atominfo.xml");
+    }else{
+      fwrite(STDERR, "Using atomfile for $representationDirectory\n");
+      if ($representationDirectory != "") {
+          rename("$sessionDirectory/atominfo.xml", "$representationDirectory/atomInfo.xml");
+      }
     }
 
     return $returncode;

--- a/validation-tests/cta/validationTest.php
+++ b/validation-tests/cta/validationTest.php
@@ -116,7 +116,7 @@ final class validationTest extends TestCase
             "https://dash.akamaized.net/WAVE/vectors/avc_sets/15_30_60/t3/2022-01-17/stream.mpd"
         ];
         $content = file_get_contents(
-            "validations-tests/cta/wave.json");
+            "validation-tests/cta/wave.json");
         $dbJson = json_decode($content);
         $streamsToTest = array();
         foreach ($dbJson as $item) {


### PR DESCRIPTION
Added a 30 second timeout / 60 second kill timeout on the segment validator, to prevent it from running indefinitely.

Added a category of "health" checks to the logger module, to message various issues with the segment validator:
- The segment validator took too long and is killed
- The resulting XML file is > 100mb. (There is a set of test files that generate 2GB files of whitespace)
- The resulting XML is invalid XML

On health issues with the segment validator, segment validation is skipped for the remainder of the run.

This should address - at least a part of - issue #602

Also added some minor rewrites to address issues #612 and #614