### PR TITLE
Fix/stderr

### DIFF
--- a/CTAWAVE/impl/checkCMFHDBaselineConstraints.php
+++ b/CTAWAVE/impl/checkCMFHDBaselineConstraints.php
@@ -19,6 +19,6 @@ $logger->test(
     "CMFHD profile",
     count(array_unique($presentationProfileArray)) === 1 && array_unique($presentationProfileArray)[0] == "CMFHD",
     "FAIL",
-    "All CMAF Swithcing sets are CMFHD conformant",
-    "Not all CMAF Swithcing sets are CMFHD conformant"
+    "All CMAF Switching sets are CMFHD conformant",
+    "Not all CMAF Switching sets are CMFHD conformant"
 );

--- a/DASH/processMPD.php
+++ b/DASH/processMPD.php
@@ -146,8 +146,6 @@ function processAdaptationSetOfCurrentPeriod()
                 }
             }
 
-
-            $logger->setModule("HEALTH");
             validate_segment(
                 $adaptationDirectory,
                 $representationDirectory,

--- a/Utils/moduleLogger.php
+++ b/Utils/moduleLogger.php
@@ -105,6 +105,14 @@ class ModuleLogger
         $this->currentHook = '';
     }
 
+    public function getCurrentModule() {
+        return $this->currentModule;
+    }
+
+    public function getCurrentHook() {
+        return $this->currentHook;
+    }
+
     public function getModuleVerdict($moduleName)
     {
         if (!array_key_exists($moduleName, $this->entries)) {

--- a/Utils/segment_validation.php
+++ b/Utils/segment_validation.php
@@ -58,6 +58,9 @@ function validate_segment(
         $file_location[] = 'notexist';
     }
 
+    // Save content of stderr
+    saveStdErrOutput($representationDirectory);
+
     return $file_location;
 }
 
@@ -527,4 +530,30 @@ function checkSegmentDurationWithMPD($segmentsTime, $PTO, $duration, $representa
             "Incorrect for segment $i with duration " . $segmentsTime[0][$i]['earliestPresentationTime']
         );
     }
+}
+
+function saveStdErrOutput($representationDirectory) {
+    global $logger;
+
+    $currentModule = $logger->getCurrentModule();
+    $currentHook = $logger->getCurrentHook();
+    $path = "$representationDirectory/stderr.txt";
+    $file = fopen( $path,'r');
+    $filesize = filesize($path);
+    $content = fread($file,$filesize);
+    $logger->setModule("SEGMENT_VALIDATION");
+    $logger->test(
+        "Segment Validation",
+        "Segment Validation",
+        "std error output",
+        $filesize == 0 || $filesize == false || $file == false,
+        "FAIL",
+        "Segment validation did not produce any errors",
+        $content
+    );
+
+    fclose($file);
+    // Restore module information since health checks are over
+    $logger->setModule($currentModule);
+    $logger->setHook($currentHook);
 }


### PR DESCRIPTION
This is supposed to address #613 

* `stderr.txt` is copied to the Representation subdirectories
* `HEALTH` module does no longer include MPD duration checks which causes test interruption if failing
* Output of `stderr.txt` is stored in the resulting JSON as a new entry: 
````json
SEGMENT_VALIDATION": {
      "": {
        "test": [
          {
            "spec": "Segment Validation",
            "section": "Segment Validation",
            "test": "std error output",
            "messages": [
              "..\/src\/ValidateAtoms.cpp : 3999 : colr atom of type nclx found, the software does not handle colr atoms of this type. \n..\/src\/ValidateAtomList.cpp : 2339 : WARNING: In moov-1:udta-1 - unknown\/unexpected atom 'meta'\nAccording to DASH-IF IOP Section 3.2.8 @bandwidth of the Representation (300000 bps) is set too high given the @minimumBufferTime (2 s), the minimum @bandwidth value required to conform is 296978 bps.\n"
            ],
            "state": "FAIL"
          }
        ],
        "verdict": "FAIL"
      },
      "verdict": "FAIL"
    }
```` 