### PR TITLE
Removed a false check for matrix coefficients

### DIFF
--- a/CMAF/impl/determineVideoProfileValidity.php
+++ b/CMAF/impl/determineVideoProfileValidity.php
@@ -38,7 +38,6 @@ $testMatrixCoefficients = $logger->test(
     "colour_primaries, transfer_characteristics and matrix_coefficients values from the options listed " .
     "in the table",
     in_array($matrixCoefficients, $validMatrixCoefficients),
-    $matrixCoefficients === "0x1" || $matrixCoefficients === "0x5" || $matrixCoefficients === "0x6",
     "FAIL",
     "Valid matrix coefficients found",
     "Nonvalid matrix coefficients found"


### PR DESCRIPTION
Fixes #649 

Issue raised was caused by an extra line in the test statement, the test performed and result were correct, only the raised message "FAIL" was wrong