### PR TITLE
Fixes/validation issues

### DIFF
--- a/CMAF/impl/checkCMAFPresentation.php
+++ b/CMAF/impl/checkCMAFPresentation.php
@@ -17,7 +17,7 @@ $trackDurArray = array();
 $longestFragmentDuration = 0;
 $videoFragDur = 0;
 
-$presentationDuration = $period_timing_info[1];
+$presentationDuration = $period_timing_info["duration"];
 $adaptationSets = $mpdHandler->getFeatures()['Period'][$mpdHandler->getSelectedPeriod()]['AdaptationSet'];
 for ($adaptationSetIndex = 0; $adaptationSetIndex < sizeof($adaptationSets); $adaptationSetIndex++) {
     $adaptationSet = $adaptationSets[$adaptationSetIndex];

--- a/CMAF/impl/checkCMAFTracks.php
+++ b/CMAF/impl/checkCMAFTracks.php
@@ -34,7 +34,7 @@ if ($xml->getElementsByTagName('hdlr')->item(0)) {
 $adaptationSet = $mpdHandler->getFeatures()['Period'][$mpdHandler->getSelectedPeriod()]
                                            ['AdaptationSet'][$mpdHandler->getSelectedAdaptationSet()];
 
-$errorInTrack = 0;
+$noErrorInTrack = true;
 $id = $adaptationSet['Representation'][$mpdHandler->getSelectedAdaptationSet()]['id'];
 $moofBoxes = $xml->getElementsByTagName('moof');
 $moofBoxesCount = $moofBoxes->length;
@@ -100,7 +100,7 @@ for ($j = 1; $j < $moofBoxesCount; $j++) {
     $previousFragmentDecodeTime = $tfdtBoxes->item($j - 1)->getAttribute('baseMediaDecodeTime');
     $currentFragmentDecodeTime = $tfdtBoxes->item($j)->getAttribute('baseMediaDecodeTime');
 
-    $errorInTrack |= $logger->test(
+    $noErrorInTrack &= $logger->test(
         "CMAF",
         "Section 7.3.2.2",
         "Each CMAF Fragment in a CMAF Track SHALL have baseMediaDecodeTime equal to the sum of all prior " .
@@ -110,7 +110,7 @@ for ($j = 1; $j < $moofBoxesCount; $j++) {
         "Representation $id Fragment $j valid",
         "Representation $id Fragment $j does not have a valid baseMediaDecodeTime"
     );
-    $errorInTrack |= $logger->test(
+    $noErrorInTrack &= $logger->test(
         "CMAF",
         "Section 7.3.2.3",
         "CMAF Chunks in a CMAF Track SHALL NOT overlap or have gaps in decode time",
@@ -178,7 +178,7 @@ $logger->test(
     "Section 7.3.2.2",
     "The concatenation of a CMAF Header and all CMAF Fragments in the CMAF Track in consecutive decode order " .
     "SHALL be a valid fragmented ISOBMFF file",
-    !$errorInTrack,
+    $noErrorInTrack,
     "FAIL",
     "Representation $id valid",
     "Representation $id not valid"

--- a/CMAF/impl/checkCMAFTracks.php
+++ b/CMAF/impl/checkCMAFTracks.php
@@ -370,8 +370,8 @@ if ($hdlrType == 'vide' && ($sdType == 'avc1' || $sdType == 'avc3')) {
             "decoded and displayed when independently accessed",
             $numberOfUnitsInTick != null && $timeScale != null,
             "FAIL",
-            "FPS info found for representation / track $id",
-            "FPS info not found for representation / track $id",
+            "FPS info (num_ticks & timescale) found for representation / track $id",
+            "FPS info (num_ticks & timescale) not found for representation / track $id",
         );
     }
 }

--- a/CTAWAVE/impl/CTACheckPresentation.php
+++ b/CTAWAVE/impl/CTACheckPresentation.php
@@ -179,10 +179,9 @@ if (in_array("", $presentationProfileArray)) {
 }
 
 
-if ($presentationProfile != "") {
-
+if ($presentationProfile != ""){
+  $logger->message("Stream found to conform to a CMAF Presentation Profile: $presentationProfile");
 }
 
-$logger->message("Stream found to conform to a CMAF Presentation Profile: $presentationProfile");
 
 return $presentationProfile;

--- a/CTAWAVE/impl/CTACheckPresentation.php
+++ b/CTAWAVE/impl/CTACheckPresentation.php
@@ -183,5 +183,7 @@ if ($presentationProfile != ""){
   $logger->message("Stream found to conform to a CMAF Presentation Profile: $presentationProfile");
 }
 
+$this->presentationProfile = $presentationProfile;
+
 
 return $presentationProfile;

--- a/CTAWAVE/impl/CTACheckPresentation.php
+++ b/CTAWAVE/impl/CTACheckPresentation.php
@@ -2,7 +2,9 @@
 
 global $logger, $session, $mpdHandler;
 
-$adaptationCount = sizeof($mpdHandler->getFeatures()['Period'][$mpdHandler->getSelectedPeriod()]['AdaptationSet']);
+if (is_null($adaptationCount)) {
+    $adaptationCount = sizeof($mpdHandler->getFeatures()['Period'][$mpdHandler->getSelectedPeriod()]['AdaptationSet']);
+}
 
 $chfdSwitchingSetFound = 0;
 $videoSelectionSetFound = 0;
@@ -19,7 +21,10 @@ $presentationProfile = "";
 for ($adaptationIndex = 0; $adaptationIndex < $adaptationCount; $adaptationIndex++) {
     $switchingSetMediaProfiles = array();
     $encryptedTracks = array();
-    $location = $session->getAdaptationDir($mpdHandler->getSelectedPeriod(), $adaptationIndex);
+    if(is_null($periodIndex)) {
+        $periodIndex = $mpdHandler->getSelectedPeriod();
+    }
+    $location = $session->getAdaptationDir($periodIndex, $adaptationIndex);
     $fileCount = 0;
     $files = DASHIF\rglob("$location/*.xml");
     if ($files) {
@@ -174,9 +179,10 @@ if (in_array("", $presentationProfileArray)) {
 }
 
 
-if ($presentationProfile != ""){
+if ($presentationProfile != "") {
 
 }
 
 $logger->message("Stream found to conform to a CMAF Presentation Profile: $presentationProfile");
 
+return $presentationProfile;

--- a/CTAWAVE/impl/CTACheckPresentation.php
+++ b/CTAWAVE/impl/CTACheckPresentation.php
@@ -52,7 +52,7 @@ for ($adaptationIndex = 0; $adaptationIndex < $adaptationCount; $adaptationIndex
         $hdlrType = $hdlrBox->getAttribute("handler_type");
 
         $mediaProfileResult = $this->getMediaProfile($xml, $hdlrType, $fileIndex, $adaptationIndex);
-        array_push($switchingSetMediaProfiles, $mediaProfileResult[0]);
+        array_push($switchingSetMediaProfiles, $mediaProfileResult);
 
         if ($hdlrType == "vide") {
             $videoSelectionSetFound = 1;

--- a/CTAWAVE/impl/CTACheckSelectionSet.php
+++ b/CTAWAVE/impl/CTACheckSelectionSet.php
@@ -52,7 +52,7 @@ for ($adaptationIndex = 0; $adaptationIndex < $adaptationCount; $adaptationIndex
         $hdlrBox = $xml->getElementsByTagName("hdlr")->item(0);
         $hdlrType = $hdlrBox->getAttribute("handler_type");
         $mediaProfileTrackResult = $this->getMediaProfile($xml, $hdlrType, $fileIndex, $adaptationIndex);
-        $mediaProfileTrack = $mediaProfileTrackResult[0];
+        $mediaProfileTrack = $mediaProfileTrackResult;
 
         //Update the MP database for future checks
         $MediaProfDatabase[$mpdHandler->getSelectedPeriod()][$adaptationIndex][$fileIndex] = $mediaProfileTrack;

--- a/CTAWAVE/impl/checkCMFHDBaselineConstraints.php
+++ b/CTAWAVE/impl/checkCMFHDBaselineConstraints.php
@@ -9,7 +9,7 @@ $presentationProfileArray = array();
 for ($i = 0; $i < $periodCount; $i++) {
     $adaptationCount = sizeof($MediaProfDatabase[$i]);
     $presentationProfile = $this->CTACheckPresentation($adaptationCount, $i);
-    array_push($presentationProfileArray, $presentationProfile);
+    $presentationProfileArray[] = $presentationProfile;
 }
 
 $logger->test(

--- a/CTAWAVE/impl/checkCMFHDBaselineConstraints.php
+++ b/CTAWAVE/impl/checkCMFHDBaselineConstraints.php
@@ -1,24 +1,14 @@
 <?php
 
-global $MediaProfDatabase, $session, $logger;
-
-//Check for CMFHD presentation profile for all periods/presentations
-//and then check WAVE Baseline constraints . If both are satisfied, then CMFHD Baseline Constraints are satisfied.
-$periodCount = sizeof($MediaProfDatabase);
-$presentationProfileArray = array();
-for ($i = 0; $i < $periodCount; $i++) {
-    $adaptationCount = sizeof($MediaProfDatabase[$i]);
-    $presentationProfile = $this->CTACheckPresentation($adaptationCount, $i);
-    $presentationProfileArray[] = $presentationProfile;
-}
+global $session, $logger;
 
 $logger->test(
     "WAVE Content Spec 2018Ed",
     "Section 6.2",
     "WAVE CMFHD Baseline Program Shall contain a sequence of one or more CMAF Presentations conforming to CMAF " .
     "CMFHD profile",
-    count(array_unique($presentationProfileArray)) === 1 && array_unique($presentationProfileArray)[0] == "CMFHD",
+    $this->presentationProfile == "CMFHD",
     "FAIL",
     "All CMAF Switching sets are CMFHD conformant",
-    "Not all CMAF Switching sets are CMFHD conformant"
+    "Not all CMAF Switching sets are CMFHD conformant, found $presentationProfile"
 );

--- a/CTAWAVE/module.php
+++ b/CTAWAVE/module.php
@@ -7,6 +7,7 @@ class ModuleCTAWAVE extends ModuleInterface
     private $mediaProfileAttributesAudio;
     private $mediaProfileAttributesVideo;
     private $mediaProfileAttributesSubtitle;
+    private $presentationProfile;
 
     public function __construct()
     {

--- a/CTAWAVE/module.php
+++ b/CTAWAVE/module.php
@@ -176,9 +176,9 @@ class ModuleCTAWAVE extends ModuleInterface
         return include 'impl/checkAudioChannelSplicePoint.php';
     }
 
-    private function CTACheckPresentation()
+    private function CTACheckPresentation($adaptationCount = null, $periodIndex = null)
     {
-        include 'impl/CTACheckPresentation.php';
+        return include 'impl/CTACheckPresentation.php';
     }
     private function CTACheckSelectionSet()
     {

--- a/DASH/LowLatency/impl/validateSegmentTimeline.php
+++ b/DASH/LowLatency/impl/validateSegmentTimeline.php
@@ -42,7 +42,7 @@ foreach ($segementElements as $sIndex => $s) {
 
     if ($r < 0) {
         $until = ($sIndex != $segmentElementCount - 1) ?
-          $segmentElements[$sIndex + 1]['t'] : $period_timing_info[1] * $timescale;
+          $segmentElements[$sIndex + 1]['t'] : $period_timing_info["duration"] * $timescale;
         while ($t < $until) {
             $logger->test(
                 "DASH-IF IOP CR Low Latency Live",

--- a/HbbTV_DVB/impl/mpdTimingInfo.php
+++ b/HbbTV_DVB/impl/mpdTimingInfo.php
@@ -11,7 +11,7 @@ foreach ($segment_access as $seg_acc) {
     $duration = ($seg_acc['duration'] != '') ? (int)($seg_acc['duration']) : 0;
     $timescale = ($seg_acc['timescale'] != '') ? (int)($seg_acc['timescale']) : 1;
 
-    $pres_start = $period_timing_info[0] - $pto / $timescale;
+    $pres_start = $period_timing_info["start"] - $pto / $timescale;
 
     $segtimeline = $seg_acc['SegmentTimeline'];
     if ($segtimeline != null && sizeof($segtimeline) != 0) {
@@ -37,7 +37,7 @@ foreach ($segment_access as $seg_acc) {
                         $index++;
                     }
                 } else {
-                    $segment_cnt = ceil($period_timing_info[1] / $segmentDuration);
+                    $segment_cnt = ceil($period_timing_info["duration"] / $segmentDuration);
 
                     for ($i = 0; $i < $segment_cnt; $i++) {
                         $mpd_timing[] = $pres_start + $i * $segmentDuration;
@@ -54,7 +54,7 @@ foreach ($segment_access as $seg_acc) {
             $mpd_timing[] = $pres_start;
         } else {
             $segmentDuration = $duration / $timescale;
-            $segment_cnt = $period_timing_info[1] / $segmentDuration;
+            $segment_cnt = $period_timing_info["duration"] / $segmentDuration;
 
             for ($i = 0; $i < $segment_cnt; $i++) {
                 $mpd_timing[] = $pres_start + $i * $segmentDuration;

--- a/HbbTV_DVB/impl/representationValidation.php
+++ b/HbbTV_DVB/impl/representationValidation.php
@@ -21,7 +21,7 @@ if ($xmlRepresentation) {
     $this->segmentTimingCommon($xmlRepresentation);
     $this->bitrateReport($xmlRepresentation);
     $segmentDurationName = $this->segmentDurationChecks();
-    if ($period_timing_info[1] !== '' && $period_timing_info[1] !== 0) {
+    if ($period_timing_info["duration"] !== '' && $period_timing_info["duration"] !== 0) {
         $checks = $this->segmentToPeriodDurationCheck($xmlRepresentation);
         $logger->test(
             "HbbTV-DVB DASH Validation Requirements",

--- a/HbbTV_DVB/impl/segmentToPeriodDurationCheck.php
+++ b/HbbTV_DVB/impl/segmentToPeriodDurationCheck.php
@@ -15,7 +15,7 @@ for ($j = 0; $j < $moofBoxCount; $j++) {
     $totalSegmentDuration += $segmentDuration;
 }
 
-$periodDuration = (float)$period_timing_info[1];
+$periodDuration = (float)$period_timing_info["duration"];
 
 $drift = 0;
 if (round($periodDuration, 2) != 0) {

--- a/Utils/impl/MPDHandler/computeDynamicIntervals.php
+++ b/Utils/impl/MPDHandler/computeDynamicIntervals.php
@@ -45,7 +45,7 @@ $buffercapacity = $bufferduration / $segmentduration; //actual buffer capacity
 date_default_timezone_set("UTC"); //Set default timezone to UTC
 $now = time(); // Get actual time
 $AST = strtotime($AST);
-$LST = $now - ($AST + $period_timing_info[0] - $pto - $availabilityTimeOffset - $segmentduration);
+$LST = $now - ($AST + $period_timing_info["start"] - $pto - $availabilityTimeOffset - $segmentduration);
 $LSN = intval($LST / $segmentduration);
 $earliestsegment = $LSN - $buffercapacity * $percent;
 

--- a/Utils/impl/MPDHandler/getDurationsForAllPeriods.php
+++ b/Utils/impl/MPDHandler/getDurationsForAllPeriods.php
@@ -37,7 +37,7 @@ for ($i = 0; $i < sizeof($periods); $i++) {
         }
     }
 
-    if ($periodDuration != '') {
+    if ($periodDuration != '' && $periodDuration != null) {
         $duration = DASHIF\Utility\timeParsing($periodDuration);
     } else {
         if ($i != sizeof($periods) - 1) {

--- a/Utils/impl/MPDHandler/getPeriodDurationInfo.php
+++ b/Utils/impl/MPDHandler/getPeriodDurationInfo.php
@@ -1,7 +1,11 @@
 <?php
+global $period_timing_info;
 
 if (empty($this->periodTimingInformation)) {
     $this->getDurationForAllPeriods();
 }
 
-return $this->periodTimingInformation[$period];
+
+$period_timing_info = $this->periodTimingInformation[$period];
+
+return $period_timing_info;

--- a/Utils/moduleLogger.php
+++ b/Utils/moduleLogger.php
@@ -139,10 +139,10 @@ class ModuleLogger
     public function test($spec, $section, $test, $check, $fail_type, $msg_succ, $msg_fail)
     {
         if ($check) {
-            $this->addTestResult($spec, $section, $test, $msg_succ, "PASS");
+            $this->addTestResult($spec, $section, $test, "✓ " . $msg_succ, "PASS");
             return true;
         } else {
-            $this->addTestResult($spec, $section, $test, $msg_fail, $fail_type);
+            $this->addTestResult($spec, $section, $test, ($fail_type == "WARN" ? "! " : "✗ ") . $msg_fail, $fail_type);
             return false;
         }
     }

--- a/Utils/segment_validation.php
+++ b/Utils/segment_validation.php
@@ -280,7 +280,7 @@ function run_backend($configFile, $representationDirectory = "")
 
     $atomXmlString = file_get_contents("$sessionDirectory/atominfo.xml");
     $STYPBeginPos = strpos($atomXmlString, "<styp");
-    if ($STYPBugPos !== false) {
+    if ($STYPBeginPos !== false) {
         //try with newline for prettyprinted
         $emptyCompatBrands = strpos($atomXmlString, "compatible_brands='[\n  </styp>", $STYPBeginPos);
         if ($emptyCompatBrands === false) {
@@ -348,8 +348,12 @@ function config_file_for_backend($period, $adaptation_set, $representation, $rep
     fwrite($file, "$representationDirectory/assemblerInfo.txt \n");
 
     if (!$is_dolby) {
-        fwrite($file, "-offsetinfo" . "\n");
-        fwrite($file, "$representationDirectory/mdatoffset \n");
+        if (file_exists("$representationDirectory/mdatoffset") && filesize("$representationDirectory/mdatoffset") > 0) {
+            fwrite($file, "-offsetinfo" . "\n");
+            fwrite($file, "$representationDirectory/mdatoffset \n");
+        } else {
+            fwrite($file, "-c 1" . "\n");
+        }
     }
 
     $flags = (!$hls_manifest) ? construct_flags(
@@ -497,7 +501,7 @@ function checkSegmentDurationWithMPD($segmentsTime, $PTO, $duration, $representa
     $segmentDur = array();
     $num_segments = sizeof($segmentsTime[0]);
     if ($mpdHandler->getSelectedPeriod() == 0) {
-        $pres_start = $period_timing_info[0] + $PTO;
+        $pres_start = $period_timing_info["start"] + $PTO;
     } else {
         $pres_start = $PTO;
     }

--- a/Utils/segment_validation.php
+++ b/Utils/segment_validation.php
@@ -545,6 +545,7 @@ function saveStdErrOutput($representationDirectory, $saveDetailedOutput = true)
     $currentModule = $logger->getCurrentModule();
     $currentHook = $logger->getCurrentHook();
     $logger->setModule("SEGMENT_VALIDATION");
+    $logger->setHook("Segment Validation");
 
     $content = file_get_contents("$representationDirectory/stderr.txt");
     $contentArray = explode("\n", $content);
@@ -553,7 +554,7 @@ function saveStdErrOutput($representationDirectory, $saveDetailedOutput = true)
         $logger->test(
             "Segment Validation",
             "Segment Validation",
-            "Check for content in error log",
+            "Segment validator output should not contain errors",
             true,
             "PASS",
             "Segment validation did not produce any output",
@@ -582,7 +583,7 @@ function saveStdErrOutput($representationDirectory, $saveDetailedOutput = true)
                 $logger->test(
                     "Segment Validation",
                     "Segment Validation",
-                    "Check for content in error log",
+                    "Segment validator output should not contain errors",
                     $severity == "PASS",
                     $severity,
                     $msg,
@@ -595,7 +596,7 @@ function saveStdErrOutput($representationDirectory, $saveDetailedOutput = true)
             $logger->test(
                 "Segment Validation",
                 "Segment Validation",
-                "Check for content in error log",
+                "Segment validator output should not contain errors",
                 $commonSeverity == "PASS",
                 $commonSeverity,
                 "Segment validation did not produce any errors",


### PR DESCRIPTION
Fixes for: 
- Media profile in WAVE
- Media profile propagation
- There was a issue with the check for section 7.3.2.3 where we checked for "no errors" in a variable named error, leading to the wrong verdict
- Quality of life improvement to the wording considering stderr output
- Quality of life improvement where ALL test messages now get prepended with a state symbol, making it easier to find fail messages in the interface.