### PR TITLE
fix: use URL instatiation to validate url string

### DIFF
--- a/Conformance-Frontend/lib/net.js
+++ b/Conformance-Frontend/lib/net.js
@@ -38,18 +38,13 @@ const Net = (function () {
     form.submit();
   }
 
-  // https://www.freecodecamp.org/news/check-if-a-javascript-string-is-a-url/
   function isValidUrl(urlString) {
-    let urlPattern = new RegExp(
-      "^(https?:\\/\\/)?" + // validate protocol
-        "((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|" + // validate domain name
-        "((\\d{1,3}\\.){3}\\d{1,3}))" + // validate OR ip (v4) address
-        "(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*" + // validate port and path
-        "(\\?[;&a-z\\d%_.~+=-]*)?" + // validate query string
-        "(\\#[-a-z\\d_]*)?$",
-      "i"
-    ); // validate fragment locator
-    return !!urlPattern.test(urlString);
+    try {
+      const url = new URL(urlString);
+      return url.protocol === "http:" || url.protocol === "https:";
+    } catch (_) {
+      return false;
+    }
   }
 
   let instance = {


### PR DESCRIPTION
The current URL validation regex yields some false negatives. 
For example, `https://test.com/foo:123/manifest.mpd` is marked as invalid despite it being a valid URL.

The simplest approach is to try and instantiate an URL object.