### PR TITLE
Fix accessing the wrong attribute for the NAL unit type

### DIFF
--- a/CMAF/impl/determineCMAFMediaProfiles.php
+++ b/CMAF/impl/determineCMAFMediaProfiles.php
@@ -91,7 +91,7 @@ if ($hdlrType == 'vide') {
         $nalUnits = $xml->getElementsByTagName("NALUnit");
         if ($nalUnits->length != 0) {
             for ($nalIndex = 0; $nalIndex < $nalUnits->length; $nalIndex++) {
-                if ($nalUnits->item($nalIndex)->getAttribute("nalUnits_type") == "33") {
+                if ($nalUnits->item($nalIndex)->getAttribute("nal_unit_type") == "33") {
                     $spsUnitIndex = $nalIndex;
                     break;
                 }

--- a/CTAWAVE/impl/getMediaProfile.php
+++ b/CTAWAVE/impl/getMediaProfile.php
@@ -109,7 +109,7 @@ if ($hdlrType == 'vide') {
         }
 
         for ($nalIndex = 0; $nalIndex < $nalUnits->length; $nalIndex++) {
-            if ($nalUnits->item($nalIndex)->getAttribute("nalUnits_type") == "33") {
+            if ($nalUnits->item($nalIndex)->getAttribute("nal_unit_type") == "33") {
                 $spsIndex = $nalIndex;
                  break;
             }


### PR DESCRIPTION
This should be related to https://github.com/cta-wave/Test-Content/issues/38 . Because of a wrong attribute the required information was not read from `atominfo.xml` 