### PR TITLE
Introduce processing statistics

### DIFF
--- a/Conformance-Frontend/index.html
+++ b/Conformance-Frontend/index.html
@@ -38,6 +38,7 @@
   <script src="./src/main-view.js"></script>
   <script src="./src/tool-view.js"></script>
   <script src="./src/about-view.js"></script>
+  <script src="./src/statistics-view.js"></script>
   <script src="./src/faq-view.js"></script>
   <script src="./main.js"></script>
 </body>

--- a/Conformance-Frontend/src/get-access.sh
+++ b/Conformance-Frontend/src/get-access.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+/usr/bin/egrep '(GET|POST) /Utils/Process_cli.php' /var/log/apache2/access.log

--- a/Conformance-Frontend/src/main-view.js
+++ b/Conformance-Frontend/src/main-view.js
@@ -6,6 +6,7 @@ function MainView() {
   const locations = [
     { id: "home", text: "Validator", icon: "fa-solid fa-gears", view: ToolView },
     { id: "about", text: "About", icon: "fa-solid fa-info-circle", view: AboutView },
+    { id: "statistics", text: "Statistics", icon: "fa-solid fa-bar-chart", view: StatisticsView },
     { id: "faq", text: "FAQ", icon: "fa-solid fa-question-circle", view: FaqView },
   ];
 

--- a/Conformance-Frontend/src/statistics-view.js
+++ b/Conformance-Frontend/src/statistics-view.js
@@ -1,0 +1,46 @@
+function StatisticsView() {
+  let instance = {};
+
+  let _state = {
+    markdown: null,
+  };
+
+  let _rootElementId;
+
+  async function loadMarkdown() {
+    _state.markdown = await Net.sendRequest({
+      method: "GET",
+      uri: "./static/statistics-page.php",
+    });
+    render();
+  }
+
+  function generateContent() {
+    if (!_state.markdown) return;
+    return Tools.markdownToHtml(_state.markdown);
+  }
+
+  function render(rootElementId) {
+    _rootElementId = rootElementId = rootElementId || _rootElementId;
+
+    let aboutView = UI.createElement({
+      id: rootElementId,
+    });
+
+    if (!_state.markdown) {
+      loadMarkdown();
+      return;
+    }
+
+    let content = generateContent();
+    aboutView.appendChild(content);
+
+    UI.replaceElement(_rootElementId, aboutView);
+  }
+
+  instance = {
+    render,
+  };
+
+  return instance;
+}

--- a/Conformance-Frontend/static/statistics-page.php
+++ b/Conformance-Frontend/static/statistics-page.php
@@ -1,0 +1,43 @@
+<?php
+
+function entry($diff,$limit,$ip,&$table) {
+  if ($diff < $limit) {
+    $table[$ip] = isset($table[$ip]) ? $table[$ip]+1 : 1;
+  }
+}
+
+// hold accesses in the last week, month, or quarter, keyed by IP address
+$ip_in_week = array();
+$ip_in_month = array();
+$ip_in_quarter = array();
+
+$now = date_timestamp_get(date_create());
+
+// parse the access log and get all lines referring to /Utils/Process_cli.php
+$output = `sudo /var/www/html/Conformance-Frontend/src/get-access.sh`;
+
+// now go through the log line by line, storing IP vs date
+foreach(preg_split("/((\r?\n)|(\r\n?))/", $output) as $line) {
+  $ip = preg_replace("/^([^ ]*)\s.*$/", "$1", $line);
+  $date = preg_replace("/^.*(\[[^ ]+ [^ ]+\]).*$/","$1", $line); // [16/Jun/2023:10:22:36 +0000]
+  $timestamp = DateTime::createFromFormat(
+    '[d/M/Y:H:i:s O]',
+    $date,
+    new DateTimeZone('EST')
+  );
+
+  if ($timestamp !== false) {
+    $before = $now - $timestamp->getTimestamp();
+
+    define("SEC_IN_DAY",24*60*60);
+    entry($before,7*SEC_IN_DAY,$ip,$ip_in_week);
+    entry($before,31*SEC_IN_DAY,$ip,$ip_in_month);
+    entry($before,(31+31+30)*SEC_IN_DAY,$ip,$ip_in_quarter);
+  }
+}
+
+echo "<table><tr>accesses<th></th><th>per week</th><th>per month</th><th>per quarter</th></tr>";
+echo "<tr><th>unique</th><td>",count($ip_in_week),"</td><td>",count($ip_in_month),"</td><td>",count($ip_in_quarter),"</td>";
+echo "<tr><th>total</th><td>",array_sum($ip_in_week),"</td><td>",array_sum($ip_in_month),"</td><td>",array_sum($ip_in_quarter),"</td></table>";
+
+?>

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,19 +4,27 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 EXPOSE 80
 
-RUN apt-get update
+RUN apt-get update -y
 RUN apt -y install \
   apache2 apache2-doc php php-dev php-xml php-curl php-xdebug libapache2-mod-php \
   python2.7 \
   openjdk-8-jdk ant \
+  sudo \
   g++
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
 RUN python2.7 get-pip.py
 RUN pip2 install matplotlib
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
+# let apache sudo this one specific script which filters the access logs
+RUN echo >> /etc/sudoers "www-data ALL=NOPASSWD: /var/www/html/Conformance-Frontend/src/get-access.sh"
+
 RUN rm /var/www/html/index.html
 COPY --chown=www-data:www-data . /var/www/html/
+
+COPY --chown=www-data:www-data ISOSegmentValidator /var/www/html/ISOSegmentValidator
 RUN cd /var/www/html/ISOSegmentValidator/public/linux && make clean && make -j
+
+COPY --chown=www-data:www-data Conformance-Frontend /var/www/html/Conformance-Frontend
 
 CMD apachectl -D FOREGROUND


### PR DESCRIPTION
This is a proof of concept implementation for a statistics page, showing accesses to the tool.
The implementation uses the server access log and greps for "GET" and "POST" on /Utils/Process_cli.php which seem to give all the statistics that are needed.

The script that parses the access logs needs to run with root privileges. Only user www-data can call the script as root, and it is not writable for anyone except www-data. Careful review is suggested.

The output is further processed and analyzed by a php script. The php script makes a half-hearted attempt to find "unique accesses" by using the ip address of the requesting host. It is unknown whether the resulting statistics are very useful, but absent using cookies this is probably the best that can be done.
