### PR TITLE
bugfix: address various typos and spelling errors in HbbTV module

### DIFF
--- a/DASH/mpdvalidator/schematron/dvb-dash.sch
+++ b/DASH/mpdvalidator/schematron/dvb-dash.sch
@@ -37,7 +37,7 @@
 			<assert test="dash:Role[@schemeIdUri='urn:mpeg:dash:role:2011']">Every AC-4 or MPEG-H Audio Preselection element shall include at least one Role element using the scheme
 				"urn:mpeg:dash:role:2011" as defined in ISO/IEC 23009-1:2019 [1].</assert>
 
-			<!-- the ID of the bundle is that ID which points to an AdapationSet which is not an Auxiliary -->
+			<!-- the ID of the bundle is that ID which points to an AdaptationSet which is not an Auxiliary -->
 			<let name="psc" value="tokenize(@preselectionComponents,' ')"/>
 			<let name="bundleID" value="../dash:AdaptationSet[@id = $psc][not(dlb:isAuxiliaryStream(.))]/@id"/>
 

--- a/HbbTV_DVB/impl/computeTimerange.php
+++ b/HbbTV_DVB/impl/computeTimerange.php
@@ -56,7 +56,7 @@ foreach ($timeRange as $timestamp) {
                     $p == 0,
                     "WARN",
                     "Valid value",
-                    "Uses W3C Media Fragment format with \"npt\" but fraciton notation is used"
+                    "Uses W3C Media Fragment format with \"npt\" but fraction notation is used"
                 );
 
                 $logger->test(

--- a/HbbTV_DVB/impl/crossvalidationDVBAudio.php
+++ b/HbbTV_DVB/impl/crossvalidationDVBAudio.php
@@ -11,7 +11,7 @@ $equalRepresentationCount = (sizeof($representation1) == sizeof($representation2
 $logger->test(
     "HbbTV-DVB DASH Validation Requirements",
     "DVB: Section 10.4",
-    "Players SHALL support seamless swicthing between audio Representations which only differ in bit rate",
+    "Players SHALL support seamless switching between audio Representations which only differ in bit rate",
     $equalRepresentationCount,
     "PASS",
     "Adaptation $adaptationIndex: " .
@@ -27,7 +27,7 @@ if ($equalRepresentationCount) {
         $logger->test(
             "HbbTV-DVB DASH Validation Requirements",
             "DVB: Section 10.4",
-            "Players SHALL support seamless swicthing between audio Representations which " .
+            "Players SHALL support seamless switching between audio Representations which " .
             "only differ in bit rate",
             array_key_exists($key1, $representation2),
             "PASS",
@@ -42,7 +42,7 @@ if ($equalRepresentationCount) {
                 $logger->test(
                     "HbbTV-DVB DASH Validation Requirements",
                     "DVB: Section 10.4",
-                    "Players SHALL support seamless swicthing between audio Representations which " .
+                    "Players SHALL support seamless switching between audio Representations which " .
                     "only differ in bit rate",
                     $val1 == $val2,
                     "PASS",

--- a/HbbTV_DVB/impl/crossvalidationDVBVideo.php
+++ b/HbbTV_DVB/impl/crossvalidationDVBVideo.php
@@ -11,7 +11,7 @@ $equalRepresentationCount = (sizeof($representation1) == sizeof($representation2
 $logger->test(
     "HbbTV-DVB DASH Validation Requirements",
     "DVB: Section 10.4",
-    "Players SHALL support seamless swicthing between video Representations",
+    "Players SHALL support seamless switching between video Representations",
     $equalRepresentationCount,
     "PASS",
     "Adaptation $adaptationIndex: " .
@@ -30,7 +30,7 @@ foreach ($representation1 as $key1 => $val1) {
     $logger->test(
         "HbbTV-DVB DASH Validation Requirements",
         "DVB: Section 10.4",
-        "Players SHALL support seamless swicthing between video Representations",
+        "Players SHALL support seamless switching between video Representations",
         array_key_exists($key1, $representation2),
         "PASS",
         "Adaptation $adaptationIndex: attribute $key1 found in both" .
@@ -47,7 +47,7 @@ foreach ($representation1 as $key1 => $val1) {
             $logger->test(
                 "HbbTV-DVB DASH Validation Requirements",
                 "DVB: Section 10.4",
-                "Players SHALL support seamless swicthing between audio Representations which differ only in " .
+                "Players SHALL support seamless switching between audio Representations which differ only in " .
                 "frame rate, bit rate, profile and/or level, and resolution",
                 $val1 == $val2,
                 "PASS",
@@ -90,7 +90,7 @@ if ($frameRate1 != '' && $frameRate2 != '') {
 $logger->test(
     "HbbTV-DVB DASH Validation Requirements",
     "DVB: Section 10.4",
-    "Players SHALL support seamless swicthing between audio Representations which differ only in " .
+    "Players SHALL support seamless switching between audio Representations which differ only in " .
     "frame rate, bit rate, profile and/or level, and resolution",
     $frameRatesInSameGroup,
     "PASS",
@@ -151,7 +151,7 @@ if ($adaptation['pictureAspectRatio'] != '') {
 $logger->test(
     "HbbTV-DVB DASH Validation Requirements",
     "DVB: Section 10.4",
-    "Players SHALL support seamless swicthing between video Representations which can differ in resolution, " .
+    "Players SHALL support seamless switching between video Representations which can differ in resolution, " .
     "maintaining the same picture aspect ratio",
     $validAspectRatio,
     "PASS",

--- a/HbbTV_DVB/impl/dvbContentProtection.php
+++ b/HbbTV_DVB/impl/dvbContentProtection.php
@@ -9,7 +9,7 @@ foreach ($contentProtection as $protection) {
     $logger->test(
         "HbbTV-DVB DASH Validation Requirements",
         "DVB: Section 8.3",
-        "ContentProtection descriptor SHALL be placed at he AdaptationSet level",
+        "ContentProtection descriptor SHALL be placed at the AdaptationSet level",
         $protection->parentNode->nodeName == 'AdaptationSet',
         "FAIL",
         "Protection element found for $this->periodCount",

--- a/HbbTV_DVB/impl/dvbEventChecks.php
+++ b/HbbTV_DVB/impl/dvbEventChecks.php
@@ -30,7 +30,7 @@ foreach ($events as $event) {
     $logger->test(
         "HbbTV-DVB DASH Validation Requirements",
         "DVB: Section 9.1.2.2",
-        "In order to carry XML structured data within the string value of an MPD Event element, the data o" .
+        "In order to carry XML structured data within the string value of an MPD Event element, the data " .
         "SHALL be escaped or placed in a CDATA section in accordance with the XML specification 1.0'",
         $eventXML !== false,
         "FAIL",

--- a/HbbTV_DVB/impl/dvbMPDValidator.php
+++ b/HbbTV_DVB/impl/dvbMPDValidator.php
@@ -355,7 +355,7 @@ foreach ($mpdHandler->getDom()->childNodes as $node) {
             }
         }
 
-        //Continuation of adapationset-level checks
+        //Continuation of adaptationset-level checks
         $adaptationContentType = $adaptationSet->getAttribute("contentType");
         $adaptationMimeType = $adaptationSet->getAttribute("mimeType");
 

--- a/HbbTV_DVB/impl/dvbPeriodContinousAdaptationSetsCheck.php
+++ b/HbbTV_DVB/impl/dvbPeriodContinousAdaptationSetsCheck.php
@@ -31,7 +31,7 @@ for ($i = 0; $i < $periodCount; $i++) {
                         continue;
                     }
 
-                    ## Period continuous adapation sets are signalled.
+                    ## Period continuous adaptation sets are signalled.
                     ## Start checking for conformity according to Section 10.5.2.3
                     // Check associativity
                     $logger->test(

--- a/HbbTV_DVB/impl/dvbPeriodContinousAdaptationSetsCheck.php
+++ b/HbbTV_DVB/impl/dvbPeriodContinousAdaptationSetsCheck.php
@@ -42,8 +42,8 @@ for ($i = 0; $i < $periodCount; $i++) {
                         "be associated as defined in clause 10.5.2.3",
                         in_array("$i $a1 $j $a2", $associativity),
                         "FAIL",
-                        "Associated values found for Adaptation $a1 period $i, and Adapation $a2 period $j",
-                        "Associated values not found for Adaptation $a1 period $i, and Adapation $a2 period $j"
+                        "Associated values found for Adaptation $a1 period $i, and Adaptation $a2 period $j",
+                        "Associated values not found for Adaptation $a1 period $i, and Adaptation $a2 period $j"
                     );
                     // EPT1 comparisons within the Adaptation Sets
                     if ($i != 0) {

--- a/HbbTV_DVB/impl/dvbSubtitleChecks.php
+++ b/HbbTV_DVB/impl/dvbSubtitleChecks.php
@@ -143,7 +143,7 @@ foreach ($representations as $representation) {
             $logger->test(
                 "HbbTV-DVB DASH Validation Requirements",
                 "DVB: Section 7.1.2",
-                "In oder to allow a Player to identify the primary purpose of a subtitle track, " .
+                "In order to allow a Player to identify the primary purpose of a subtitle track, " .
                 "the language attribute SHALL be set on the Adaptation Set",
                 $adaptation->getAttribute('lang') != '',
                 "FAIL",

--- a/HbbTV_DVB/impl/hbbMPDValidator.php
+++ b/HbbTV_DVB/impl/hbbMPDValidator.php
@@ -166,7 +166,7 @@ foreach ($mpdHandler->getDom()->childNodes as $node) {
         $this->adaptationSetCount <= 64,
         "FAIL",
         "$this->adaptationSetCount adaptation sets found in period $this->periodCount",
-        "$this->adaptationSetCount adapation sets found in period $this->periodCount"
+        "$this->adaptationSetCount adaptation sets found in period $this->periodCount"
     );
 
     $logger->test(

--- a/HbbTV_DVB/impl/hbbMPDValidator.php
+++ b/HbbTV_DVB/impl/hbbMPDValidator.php
@@ -186,7 +186,7 @@ foreach ($mpdHandler->getDom()->childNodes as $node) {
         $this->adaptationVideoCount <= 1 || $this->mainVideoFound == 1,
         "FAIL",
         "1 or less video adaptations found in period $this->periodCount, or exactly one is labeled 'main'",
-        "Invalid video adapatationset configruation found found in period $this->periodCount"
+        "Invalid video adapatationset configuration found found in period $this->periodCount"
     );
 
     $logger->test(
@@ -196,7 +196,7 @@ foreach ($mpdHandler->getDom()->childNodes as $node) {
         $this->adaptationAudioCount <= 1 || $this->mainAudioFound == 1,
         "FAIL",
         "1 or less audio adaptations found in period $this->periodCount, or exactly one is labeled 'main'",
-        "Invalid audio adapatationset configruation found found in period $this->periodCount"
+        "Invalid audio adapatationset configuration found found in period $this->periodCount"
     );
 }
 

--- a/HbbTV_DVB/impl/hbbMPDValidator.php
+++ b/HbbTV_DVB/impl/hbbMPDValidator.php
@@ -186,7 +186,7 @@ foreach ($mpdHandler->getDom()->childNodes as $node) {
         $this->adaptationVideoCount <= 1 || $this->mainVideoFound == 1,
         "FAIL",
         "1 or less video adaptations found in period $this->periodCount, or exactly one is labeled 'main'",
-        "Invalid video adapatationset configuration found found in period $this->periodCount"
+        "Invalid video adaptationset configuration found found in period $this->periodCount"
     );
 
     $logger->test(
@@ -196,7 +196,7 @@ foreach ($mpdHandler->getDom()->childNodes as $node) {
         $this->adaptationAudioCount <= 1 || $this->mainAudioFound == 1,
         "FAIL",
         "1 or less audio adaptations found in period $this->periodCount, or exactly one is labeled 'main'",
-        "Invalid audio adapatationset configuration found found in period $this->periodCount"
+        "Invalid audio adaptationset configuration found found in period $this->periodCount"
     );
 }
 

--- a/HbbTV_DVB/impl/segmentDurationChecks.php
+++ b/HbbTV_DVB/impl/segmentDurationChecks.php
@@ -115,7 +115,7 @@ if ($abs) {
         $logger->test(
             "HbbTV-DVB DASH Validation Requirements",
             "DVB: Section 'Duration Self consistency'",
-            "Durations of the fragments should match the sum all contained segmenet durations",
+            "Durations of the fragments should match the sum all contained segment durations",
             abs(($fragmentDurationSeconds - $totalSegmentDuration) / $totalSegmentDuration) <= 0.00001,
             "INFO",
             "The fragment duration of track with hdlrType '$hdlrType' in Adaptation $adaptationSetId, " .

--- a/HbbTV_DVB/impl/segmentDurationChecks.php
+++ b/HbbTV_DVB/impl/segmentDurationChecks.php
@@ -119,9 +119,9 @@ if ($abs) {
             abs(($fragmentDurationSeconds - $totalSegmentDuration) / $totalSegmentDuration) <= 0.00001,
             "INFO",
             "The fragment duration of track with hdlrType '$hdlrType' in Adaptation $adaptationSetId, " .
-            "representation $representationId matches the sum of it's segments",
+            "representation $representationId matches the sum of its segments",
             "The fragment duration of track with hdlrType '$hdlrType' in Adaptation $adaptationSetId, " .
-            "representation $representationId does not match the sum of it's segments"
+            "representation $representationId does not match the sum of its segments"
         );
     }
 }

--- a/HbbTV_DVB/impl/segmentTimingCommon.php
+++ b/HbbTV_DVB/impl/segmentTimingCommon.php
@@ -44,8 +44,8 @@ for ($j = 0; $j < $moofBoxesCount; $j++) {
             "Representations SHALL not contain gaps between the segment timings",
             $currentFragmentDecodeTime == $previousFragmentDecodeTime + $cummulatedSampleDurFragPrev,
             "FAIL",
-            "No gap between segment $j and it's predecessor",
-            "Gap found between segment $j and it's predecessor",
+            "No gap between segment $j and its predecessor",
+            "Gap found between segment $j and its predecessor",
         );
     }
     ##


### PR DESCRIPTION
This PR:

- fixes a variety of typos and spelling errors seen in the HbbTV test messages.

Note: I think there's more could be done, but some of it moves into editorial, such as "AdaptationSet" vs "adaptationset", "bit rate" vs "bitrate" and others. I can address more in this PR, or in follow ups.

Motivation: I'm working on a HbbTV integration and noticed the typos while I was using the web tool.

