### PR TITLE
convert reports into asserts

### DIFF
--- a/DASH/mpdvalidator/schematron/ac4-generic.sch
+++ b/DASH/mpdvalidator/schematron/ac4-generic.sch
@@ -27,14 +27,14 @@
 			<let name="md_compat" value="$cod[4]"/>
 
 			<!-- TS 103190-1, F.1.2.1 -->
-			<report test="$bs_ver = '00' and @mimeType != ('audio/mp4','video/mp4')">The value of the mimeType attribute shall be set to 'audio/mp4' or 'video/mp4'.</report>
+			<assert test="$bs_ver != '00' or @mimeType != ('audio/mp4','video/mp4')">The value of the mimeType attribute shall be set to 'audio/mp4' or 'video/mp4'.</assert>
 			<!-- TS 103190-2, G.2.6 -->
-			<report test="matches($codecs, 'ac-4\.(01|02)','i') and not(@audioSamplingRate)">@audioSamplingRate shall be set to the sampling frequency derived from the parameters fs_index and
-				dsi_sf_multiplier, contained in ac4_dsi_v1.</report>
+			<assert test="not(matches($codecs, 'ac-4\.(01|02)','i')) or @audioSamplingRate">@audioSamplingRate shall be set to the sampling frequency derived from the parameters fs_index and
+				dsi_sf_multiplier, contained in ac4_dsi_v1.</assert>
 			<!-- TS 103190-2, G.2.7 -->
-			<report test="$bs_ver = ('01','02') and @mimeType != 'audio/mp4'">The value of the mimeType attribute shall be set to 'audio/mp4'.</report>
+			<assert test="$bs_ver != ('01','02') or @mimeType = 'audio/mp4'">The value of the mimeType attribute shall be set to 'audio/mp4'.</assert>
 			<!-- TS 103190-2, G.2.8 -->
-			<report test="$bs_ver = ('01','02') and @startWithSAP != '1'">The @startWithSAP value shall be set to '1'.</report>
+			<assert test="$bs_ver != ('01','02') or @startWithSAP = '1'">The @startWithSAP value shall be set to '1'.</assert>
 		</rule>
 	</pattern>
 
@@ -50,8 +50,8 @@
 		<title>Role element for AC-4</title>
 		<rule context="dash:Role[matches(dlb:getNearestCodecString(.), 'ac-4\.00')]">
 			<!-- TS 103 190-1 F.1.3.1 -->
-			<report test="@schemeIdUri = 'urn:mpeg:dash:role:2011' and
-				not(@value = ('main','alternate','commentary','dub'))">The value of Role (role) shall be main, alternate, commentary.</report>
+			<assert test="@schemeIdUri != 'urn:mpeg:dash:role:2011' or
+				@value = ('main','alternate','commentary','dub')">The value of Role (role) shall be main, alternate, commentary.</assert>
 		</rule>
 	</pattern>
 
@@ -70,17 +70,17 @@
 			
 			<!-- AC-4 Representations should contain or inherit exactly one AudioChannelConfiguration descriptor -->
 			<!-- TS 103 190-1, F.1.2.3 -->
-			<report test="count(ancestor::*/dash:AudioChannelConfiguration[@schemeIdUri = ($NSDLB_acc2014,$NSMPEG_acc)]) &gt; 1" role="warn">
+			<assert test="count(ancestor::*/dash:AudioChannelConfiguration[@schemeIdUri = ($NSDLB_acc2014,$NSMPEG_acc)]) &lt;= 1" role="warn">
 				<xsl:text>It is recommended to use exactly one AudioChannelConfiguration element with a schemeIdURI of </xsl:text>
 				<value-of select="$NSDLB_acc2014"/> or <value-of select="$NSMPEG_acc"/>
-			</report>
+			</assert>
 
 			<!-- TS 103 190-1, F.1.4.1 -->
 			<assert test="matches(@value,'^[0-9a-fA-F]{4}$')">The value element shall contain a four-digit hexadecimal representation of the 16-bit field which describes
 				the channel assignment of the referenced AC-4 elementary stream</assert>
 			<let name="val6" value="concat('00',@value)"/>
 			<let name="x" value="dlb:dlb2mpg($val6)"/>
-			<report test="$x != 0">Use &lt;<name/> schemeIdUri="<value-of select="$NSMPEG_acc"/>" value="<value-of select="$x"/>"/&gt;</report>
+			<assert test="$x = 0">Use &lt;<name/> schemeIdUri="<value-of select="$NSMPEG_acc"/>" value="<value-of select="$x"/>"/&gt;</assert>
 		</rule>
 	</pattern>
 
@@ -90,19 +90,19 @@
 		<!-- check that only specified schemeIdUris are used -->
 		<!-- TS 103 190-2, G.2.5 -->
 		<rule context="dash:AudioChannelConfiguration[matches(dlb:getNearestCodecString(.),'ac-4\.(01|02)')][not(@schemeIdUri = ($NSDLB_acc2015,$NSMPEG_acc))]">
-			<report test="true()" role="warn">
+			<assert test="false()" role="warn">
 				Unspecified schemeIdUri in AudioChannelConfiguration element
-			</report>
+			</assert>
 		</rule>
 
 		<rule context="dash:AudioChannelConfiguration[matches(dlb:getNearestCodecString(.),'ac-4\.(01|02)')][@schemeIdUri eq $NSDLB_acc2015]">
 			<!-- TS 103 190-2, G.2.5 -->
 			<!-- AC-4 Representations should contain or inherit exactly one AudioChannelConfiguration descriptor -->
-			<report test="count(ancestor::*/dash:AudioChannelConfiguration[@schemeIdUri = ($NSDLB_acc2015,$NSMPEG_acc)]) &gt; 1" role="warn">
+			<assert test="count(ancestor::*/dash:AudioChannelConfiguration[@schemeIdUri = ($NSDLB_acc2015,$NSMPEG_acc)]) &lt;= 1" role="warn">
 				<xsl:text>It is recommended to use exactly one AudioChannelConfiguration element with a schemeIdURI of </xsl:text>
 				<xsl:text></xsl:text>
 				<value-of select="$NSDLB_acc2015"/> or <value-of select="$NSMPEG_acc"/>
-			</report>
+			</assert>
 
 			<!-- TS 103 190-2, G.3.1 -->
 			<!-- AudioChannelConfiguration descriptors with schemeIDUri tag:dolby.com,2014:dash:audio_channel_configuration:2011 shall be of certain format -->
@@ -111,18 +111,18 @@
 
 			<!-- TS 103 190-2, G.2.5 -->
 			<let name="x" value="dlb:dlb2mpg(@value)"/>
-			<report test="$x != 0">For all AC-4 channel configurations that are mappable to the MPEG channel configuration scheme, the scheme described by
-				@schemeIdUri="urn:mpeg:mpegB:cicp:ChannelConfiguration" shall be used</report>
+			<assert test="$x = 0">For all AC-4 channel configurations that are mappable to the MPEG channel configuration scheme, the scheme described by
+				@schemeIdUri="urn:mpeg:mpegB:cicp:ChannelConfiguration" shall be used</assert>
 		</rule>
 
 		<rule context="dash:AudioChannelConfiguration[matches(dlb:getNearestCodecString(.),'ac-4\.(01|02)')][@schemeIdUri eq $NSMPEG_acc]">
 			<!-- TS 103 190-2, G.2.5 -->
 			<!-- AC-4 Representations should contain or inherit exactly one AudioChannelConfiguration descriptor -->
-			<report test="count(ancestor::*/dash:AudioChannelConfiguration[@schemeIdUri = ($NSDLB_acc2015,$NSMPEG_acc)]) &gt; 1" role="warn">
+			<assert test="count(ancestor::*/dash:AudioChannelConfiguration[@schemeIdUri = ($NSDLB_acc2015,$NSMPEG_acc)]) &lt;= 1" role="warn">
 				<xsl:text>It is recommended to use exactly one AudioChannelConfiguration element with a schemeIdURI of </xsl:text>
 				<xsl:text></xsl:text>
 				<value-of select="$NSDLB_acc2015"/> or <value-of select="$NSMPEG_acc"/>
-			</report>
+			</assert>
 
 			<!-- TS 103 190-2, G.3.2 -->
 			<!-- AudioChannelConfiguration descriptors with schemeIDUri urn:mpeg:mpegB:cicp:ChannelConfiguration shall be of certain format -->

--- a/DASH/mpdvalidator/schematron/dvb-dash.sch
+++ b/DASH/mpdvalidator/schematron/dvb-dash.sch
@@ -12,22 +12,22 @@
 		<!-- Check the conformance of AdaptationSet -->
 		<rule context="dash:MPD[$dvbdash-profile-2017 = tokenize(@profiles,' ')]/dash:Period/dash:AdaptationSet[dlb:isAdaptationSetAudio(.)][not(dlb:isAuxiliaryStream(.))]/dash:Representation">
 			<!--  see="https://www.etsi.org/deliver/etsi_ts/103200_103299/103285/01.02.01_60/ts_103285v010201p.pdf#page=28" -->
-			<report test="@mimeType != ancestor::dash:AdaptationSet/dash:Representation/@mimeType">@mimeType shall be common between all Representations in an Adaptation Set</report>
+			<assert test="@mimeType = ancestor::dash:AdaptationSet/dash:Representation/@mimeType">@mimeType shall be common between all Representations in an Adaptation Set</assert>
 			<!-- see="https://www.etsi.org/deliver/etsi_ts/103200_103299/103285/01.02.01_60/ts_103285v010201p.pdf#page=28" -->
-			<report test="@codecs   != ancestor::dash:AdaptationSet/dash:Representation/@codecs" role="warn">@codecs should be common between all Representations in an Adaptation Set</report>
+			<assert test="@codecs   = ancestor::dash:AdaptationSet/dash:Representation/@codecs" role="warn">@codecs should be common between all Representations in an Adaptation Set</assert>
 			<!-- see="https://www.etsi.org/deliver/etsi_ts/103200_103299/103285/01.02.01_60/ts_103285v010201p.pdf#page=28" -->
-			<report test="@audioSamplingRate != ancestor::dash:AdaptationSet/dash:Representation/@audioSamplingRate" role="warn">@audioSamplingRate should be common between all Representations in an Adaptation Set</report>
+			<assert test="@audioSamplingRate = ancestor::dash:AdaptationSet/dash:Representation/@audioSamplingRate" role="warn">@audioSamplingRate should be common between all Representations in an Adaptation Set</assert>
 		</rule>
 		<rule context="dash:MPD[$dvbdash-profile-2017 = tokenize(@profiles,' ')]/dash:Period/dash:AdaptationSet[dlb:isAdaptationSetAudio(.)][not(dlb:isAuxiliaryStream(.))]/dash:Representation/dash:AudioChannelConfiguration">
 			<let name="siu" value="@schemeIdUri"/>
 			<let name="val" value="@value"/>
 			<!-- see="https://www.etsi.org/deliver/etsi_ts/103200_103299/103285/01.02.01_60/ts_103285v010201p.pdf#page=28" -->
-			<report test="$val != ancestor::dash:AdaptationSet/dash:Representation/dash:AudioChannelConfiguration[@schemeIdUri = $siu]/@value" role="warn">audioChannelConfiguration should be common between all Representations in an Adaptation Set</report>
+			<assert test="$val = ancestor::dash:AdaptationSet/dash:Representation/dash:AudioChannelConfiguration[@schemeIdUri = $siu]/@value" role="warn">audioChannelConfiguration should be common between all Representations in an Adaptation Set</assert>
 		</rule>
 		<rule context="dash:MPD[$dvbdash-profile-2017 = tokenize(@profiles,' ')]/dash:Period/dash:AdaptationSet[dlb:isAdaptationSetAudio(.)][dlb:isAuxiliaryStream(.)]">
 			<!-- see="https://www.etsi.org/deliver/etsi_ts/103200_103299/103285/01.02.01_60/ts_103285v010201p.pdf#page=37" -->
-			<report test="dash:AudioChannelConfiguration or dash:Role or dash:Accessibility or @lang">All Adaptation Sets that refer to Auxiliary Audio streams may not contain the @lang attribute and Role,
-				Accessibility, AudioChannelConfiguration descriptors</report>
+			<assert test="not(dash:AudioChannelConfiguration or dash:Role or dash:Accessibility or @lang)">All Adaptation Sets that refer to Auxiliary Audio streams may not contain the @lang attribute and Role,
+				Accessibility, AudioChannelConfiguration descriptors</assert>
 		</rule>
 	</pattern>
 
@@ -43,15 +43,15 @@
 
 			<!-- If there is more than one preselection in this bundle, at least one must be main -->
 			<!-- see="https://www.etsi.org/deliver/etsi_ts/103200_103299/103285/01.02.01_60/ts_103285v010201p.pdf#page=37" -->
-			<report test="count(../dash:Preselection[$bundleID = tokenize(@preselectionComponents,' ')]) &gt; 1 and not(../dash:Preselection[$bundleID = tokenize(@preselectionComponents,' ')]/dash:Role[@schemeIdUri='urn:mpeg:dash:role:2011'][@value='main'])">If there is more than one audio Preselection associated with an audio bundle, at least one of the Preselection
-				elements shall be tagged with an @value set to "main".</report>
+			<assert test="count(../dash:Preselection[$bundleID = tokenize(@preselectionComponents,' ')]) &lt;= 1 or ../dash:Preselection[$bundleID = tokenize(@preselectionComponents,' ')]/dash:Role[@schemeIdUri='urn:mpeg:dash:role:2011'][@value='main']">If there is more than one audio Preselection associated with an audio bundle, at least one of the Preselection
+				elements shall be tagged with an @value set to "main".</assert>
 
 			<!-- ISO/IEC 23009-1, 3rd edition, clause 5.3.11.3 -->
-			<report test="some $x in tokenize(@preselectionComponents,' ') satisfies not($x = preceding-sibling::dash:AdaptationSet/@id)"
+			<assert test="every $x in tokenize(@preselectionComponents,' ') satisfies $x = preceding-sibling::dash:AdaptationSet/@id"
 				diagnostics="preselID">
 				@preselectionComponents specifies the ids of the contained Adaptation Sets or Content Components that belong to this Preselection
 				as white space separated list in processing order.
-			</report>
+			</assert>
 		</rule>
 	</pattern>
 	<diagnostics>


### PR DESCRIPTION
Only the assert messages are parsed out of the schematron output, so
all report messages were effectively muted. The PR converts reports into asserts, negating the test assertion. This should fix #721 .

Note that this will likely unmask further bugs which will need to be fixed subsequently (not part of this PR).