### PR TITLE
Bugfix/upload artifact

### DIFF
--- a/.github/workflows/run-cta-wave-test-vectors.yml
+++ b/.github/workflows/run-cta-wave-test-vectors.yml
@@ -63,12 +63,13 @@ jobs:
       id: run_cli
     - uses: actions/upload-artifact@v4
       with:
+        name: cli-results-${{ matrix.submenu }}
         path: Utils/results/
   get-result:
     runs-on: ubuntu-latest
     needs: run-test-vectors
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v3
     - name: create joined result
       id: mangle
       run: |

--- a/.github/workflows/run-cta-wave-test-vectors.yml
+++ b/.github/workflows/run-cta-wave-test-vectors.yml
@@ -53,7 +53,7 @@ jobs:
         export vectors=$(cat ${{ env.TESTS_FILENAME }} |jq -j '."${{ matrix.submenu }}" |  .[].mpdPath as $url | $url, " "')
         for url in $(echo $vectors)
         do
-          outfile=results/${url//[\/:]/_}
+          outfile=results/${url//[\/:\?]/_}
           php Process_cli.php -i $url > $outfile
           if [ $(stat --format %s $outfile) -eq 31 ]
           then

--- a/.github/workflows/run-cta-wave-test-vectors.yml
+++ b/.github/workflows/run-cta-wave-test-vectors.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'development'
       - 'parallelize'
+      - 'bugfix/upload-artifact'
 
 env:
   TESTS_URL: https://cta-wave.github.io/Test-Content/database.json
@@ -60,7 +61,7 @@ jobs:
           fi
         done
       id: run_cli
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: cli-results
         path: Utils/results/

--- a/.github/workflows/run-cta-wave-test-vectors.yml
+++ b/.github/workflows/run-cta-wave-test-vectors.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: run-test-vectors
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
     - name: create joined result
       id: mangle
       run: |

--- a/.github/workflows/run-cta-wave-test-vectors.yml
+++ b/.github/workflows/run-cta-wave-test-vectors.yml
@@ -63,15 +63,12 @@ jobs:
       id: run_cli
     - uses: actions/upload-artifact@v4
       with:
-        name: cli-results
         path: Utils/results/
   get-result:
     runs-on: ubuntu-latest
     needs: run-test-vectors
     steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: cli-results
+    - uses: actions/download-artifact@v4
     - name: create joined result
       id: mangle
       run: |

--- a/.github/workflows/run-dash.js-test-vectors.yml
+++ b/.github/workflows/run-dash.js-test-vectors.yml
@@ -20,7 +20,7 @@ jobs:
         id: set-matrix
         run: |
           curl -sko ${{ env.TESTS_FILENAME }} ${{ env.TESTS_URL }}
-          echo "::set-output name=matrix::$(cat ${{ env.TESTS_FILENAME }} | jq -r -c '.items | map(.name)')"
+          echo "::set-output name=matrix::$(cat ${{ env.TESTS_FILENAME }} | jq -r -c '.items | map(.name)|unique')"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
   run-test-vectors:

--- a/.github/workflows/run-dash.js-test-vectors.yml
+++ b/.github/workflows/run-dash.js-test-vectors.yml
@@ -63,6 +63,7 @@ jobs:
       id: run_cli
     - uses: actions/upload-artifact@v4
       with:
+        name: cli-results-${{ matrix.submenu }}
         path: Utils/results/
   get-result:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-dash.js-test-vectors.yml
+++ b/.github/workflows/run-dash.js-test-vectors.yml
@@ -53,6 +53,9 @@ jobs:
         export vectors=$(cat ${{ env.TESTS_FILENAME }} |jq -j '.items[] | select(.name == "${{ matrix.submenu }}") | .submenu[].url as $url | $url, " "')
         for url in $(echo $vectors)
         do
+          if [[ $url == *"m3u8" ]]; then
+            continue
+          fi
           outfile=results/${url//[\/:\?]/_}
           php Process_cli.php -i $url > $outfile
           if [ $(stat --format %s $outfile) -eq 31 ]

--- a/.github/workflows/run-dash.js-test-vectors.yml
+++ b/.github/workflows/run-dash.js-test-vectors.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'development'
       - 'parallelize'
+      - 'bugfix/upload-artifact'
 
 env:
   TESTS_URL: https://testassets.dashif.org/dashjs.json
@@ -60,7 +61,7 @@ jobs:
           fi
         done
       id: run_cli
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: cli-results
         path: Utils/results/

--- a/.github/workflows/run-dash.js-test-vectors.yml
+++ b/.github/workflows/run-dash.js-test-vectors.yml
@@ -63,15 +63,12 @@ jobs:
       id: run_cli
     - uses: actions/upload-artifact@v4
       with:
-        name: cli-results
         path: Utils/results/
   get-result:
     runs-on: ubuntu-latest
     needs: run-test-vectors
     steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: cli-results
+    - uses: actions/download-artifact@v4
     - name: create joined result
       id: mangle
       run: |

--- a/.github/workflows/run-dash.js-test-vectors.yml
+++ b/.github/workflows/run-dash.js-test-vectors.yml
@@ -53,7 +53,7 @@ jobs:
         export vectors=$(cat ${{ env.TESTS_FILENAME }} |jq -j '.items[] | select(.name == "${{ matrix.submenu }}") | .submenu[].url as $url | $url, " "')
         for url in $(echo $vectors)
         do
-          outfile=results/${url//[\/:]/_}
+          outfile=results/${url//[\/:\?]/_}
           php Process_cli.php -i $url > $outfile
           if [ $(stat --format %s $outfile) -eq 31 ]
           then

--- a/.github/workflows/run-hbbtv-test-vectors.yml
+++ b/.github/workflows/run-hbbtv-test-vectors.yml
@@ -66,7 +66,7 @@ jobs:
         cd ..
         for url in $(echo $vectors)
         do
-          outfile=results/${url//[\/:]/_}
+          outfile=results/${url//[\/:\?]/_}
           php Process_cli.php -H -i $url > $outfile
           if [ $(stat --format %s $outfile) -eq 31 ]
           then

--- a/.github/workflows/run-hbbtv-test-vectors.yml
+++ b/.github/workflows/run-hbbtv-test-vectors.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'development'
       - 'parallelize'
+      - 'bugfix/upload-artifact'
 
 env:
   TESTS_URL: https://conformance.dashif.org/static/hbbtv-test-suite-mpds-for-motionspell.zip.gpg
@@ -73,7 +74,7 @@ jobs:
           fi
         done
       id: run_cli
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: cli-results
         path: Utils/results/

--- a/.github/workflows/run-hbbtv-test-vectors.yml
+++ b/.github/workflows/run-hbbtv-test-vectors.yml
@@ -76,6 +76,7 @@ jobs:
       id: run_cli
     - uses: actions/upload-artifact@v4
       with:
+        name: cli-results-${{ matrix.submenu }}
         path: Utils/results/
   get-result:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-hbbtv-test-vectors.yml
+++ b/.github/workflows/run-hbbtv-test-vectors.yml
@@ -76,15 +76,12 @@ jobs:
       id: run_cli
     - uses: actions/upload-artifact@v4
       with:
-        name: cli-results
         path: Utils/results/
   get-result:
     runs-on: ubuntu-latest
     needs: run-test-vectors
     steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: cli-results
+    - uses: actions/download-artifact@v4
     - name: create joined result
       id: mangle
       run: |

--- a/HLS/HLSProcessing.php
+++ b/HLS/HLSProcessing.php
@@ -160,6 +160,7 @@ function playlistToArray($url)
 function playlistURLs($array)
 {
     global $mpd_url;
+    $XMediaURLArray = array();
 
     $base_url = dirname($mpd_url);
 


### PR DESCRIPTION
Fixes #731.

I have disable the HLS testvectors for DASHJS / CMAF for now, as they crash the PHP code. (Created issue #737 to keep track of this).

Work done:
- Upgraded both upload-artifact and download-artifact to v4
- Given 'unique' names to the corresponding artifacts so they work with v4
- download-artifact now uses 'all' artifacts in the run.
- Filtered dash.js vector categories for uniqueness
- Added ? to the list of replaced url characters for filenames
- 1 HLS fix for PHP8 compliance.
- Disabled HLS testvectors

