### PR TITLE
Make unknown section more legible than ??

### DIFF
--- a/HbbTV_DVB/impl/profileSpecificMediaTypesReport.php
+++ b/HbbTV_DVB/impl/profileSpecificMediaTypesReport.php
@@ -55,7 +55,7 @@ foreach ($profile_specific_MPDs as $profile_specific_MPD) {
     $logger->test(
         "HbbTV-DVB DASH Validation Requirements",
         "MPD",
-        "??",
+        "Unknown section",
         $str == '',
         "FAIL",
         "All entries found for profile " . $mpdProfilesList[$ind],


### PR DESCRIPTION
Fixes #727 

The section of spec that is being checked is unknown. As we don't even really know which version of which spec is being checked, the only thing we can do is make this more legible than a double question mark.