### PR TITLE
Bugfix/commit sha

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,17 +33,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN  }}
-      - name: Calculate short git commit SHA
-        run: |
-          calculatedSha=$(git rev-parse --short ${{ github.sha }})
-          echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_ENV
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           push: true
           tags: ghcr.io/${{ env.REPOSITORY_LC }}:${{inputs.docker_tag}}
           build-args: |
-            SHORT_SHA:${{ env.COMMIT_SHORT_SHA }}
+            SHORT_SHA:${{ github.sha }}
       - name: Login to production server and deploy
         uses: fifsky/ssh-action@v0.0.6
         with:

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #/bin/sh
 
-docker build -t dash-if-conformance:latest -t dash-if-conformance:$(git rev-parse --short HEAD) .
+docker build --build-arg SHORT_SHA=$(git rev-parse HEAD) -t dash-if-conformance:latest -t dash-if-conformance:$(git rev-parse --short HEAD) .

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
     <body style="margin:0px;padding:0px;overflow:hidden;height:100%">
         <iframe src="Conformance-Frontend/index.html" name="targetframe" style="overflow:hidden;height:100%;width:100%" height="100%" width="100%" frameborder="0"></iframe>
         <div style="position: absolute;top: 0;right: 0;font-color:white;">Github Commit ID: <?php
-            $shortsha = getenv('SHORT_SHA');
+            $shortsha = substr(getenv('SHORT_SHA'), 0, 6);
             $githublink = "<a href=\"https://github.com/Dash-Industry-Forum/DASH-IF-Conformance/tree/$shortsha\">$shortsha</a>";
             $version = !$shortsha ? 'unknown' : $githublink;
             echo $version;


### PR DESCRIPTION
Replaces #741.

As the docker build command uses its own checkout stage, we do not have a valid git repo in our working directory.

This PR solves the issue differently, by using the 'regular' commit id as provided by github actions, and shorten it in the interface only.