### PR TITLE
Fix Docker file installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM dunglas/frankenphp AS base
 
-RUN apt-get update && apt install -y  openjdk-21-jre-headless supervisor
+RUN apt-get update && apt install -y  openjdk-21-jre-headless supervisor nodejs npm
 
 
 RUN install-php-extensions \
-    pcntl
+    pcntl zip
 
 FROM base AS builder
 
@@ -17,10 +17,19 @@ FROM base AS jccp
 
 COPY --from=builder /gpac/bin/gcc/* /usr/bin/
 
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
 ENV SERVER_NAME=:80
 COPY . /app
+
+WORKDIR /app
+
+RUN composer install --no-dev --optimize-autoloader --no-interaction && \
+    npm install && \
+    npm run build
+
+RUN php artisan migrate --force
+
 COPY laravel-queue-worker.conf /etc/supervisor/conf.d/laravel-queue-worker.conf
 
-CMD /bin/bash /app/queue_wrapper.sh
-
+CMD ["/bin/bash", "/app/queue_wrapper.sh"]


### PR DESCRIPTION
Fixed the docker installation by adding missing steps in the docker file.

Instructions to run the docker version with those fixes:

```bash
# Build the image
docker build --build-arg SHORT_SHA=$(git rev-parse HEAD) -t dash-if-conformance:latest -t dash-if-conformance:$(git rev-parse --short HEAD) .

#Create the .env file 
cp env_production.example .env

# Adding the php secret to the .env
php artisan key:generate --force
# If php not available on the host, create the secret using openssl
# sed -i "s|^APP_KEY=.*|APP_KEY=base64:$(openssl rand -base64 32)|" .env

# Run the server
docker run --name dc-server -v $PWD/.env:/app/.env -p 80:80 dash-if-conformance
```