### PR TITLE
Fixes/cmaf issues

### DIFF
--- a/app/Modules/CMAF/Segments/AudioMediaProfile.php
+++ b/app/Modules/CMAF/Segments/AudioMediaProfile.php
@@ -96,7 +96,7 @@ class AudioMediaProfile extends AdaptationComponent
         if ($sdType != 'mp4a') {
             return '____';
         }
-            return $this->validateAndDetermineBrandAAC($representation, $segment);
+        return $this->validateAndDetermineBrandAAC($representation, $segment);
     }
 
     private function validateAndDetermineBrandAAC(Representation $representation, Segment $segment): string
@@ -154,7 +154,7 @@ class AudioMediaProfile extends AdaptationComponent
 
         $this->brandCase->pathAdd(
             path: $representation->path() . "-init",
-            result: in_array($aacConfiguration['objectTypeIndication'], $allowedObjectTypes),
+            result: in_array($aacConfiguration['streamType'], $allowedObjectTypes),
             severity: "FAIL",
             pass_message: "Signalled brand $brand conforms to allowed object types",
             fail_message: "Signalled brand $brand does not conform to allowed object types",

--- a/app/Modules/CMAF/Segments/AudioMediaProfile.php
+++ b/app/Modules/CMAF/Segments/AudioMediaProfile.php
@@ -52,7 +52,9 @@ class AudioMediaProfile extends AdaptationComponent
     //Public validation functions
     public function validateAdaptationSet(AdaptationSet $adaptationSet): void
     {
-        //TODO: Only if audio
+        if (!str_starts_with($adaptationSet->getTransientAttribute('mimeType'), 'audio/')){
+            return;
+        }
         $signalledBrands = [];
 
         $segmentManager = app(SegmentManager::class);

--- a/app/Modules/CMAF/Segments/AudioMediaProfile.php
+++ b/app/Modules/CMAF/Segments/AudioMediaProfile.php
@@ -52,7 +52,7 @@ class AudioMediaProfile extends AdaptationComponent
     //Public validation functions
     public function validateAdaptationSet(AdaptationSet $adaptationSet): void
     {
-        if (!str_starts_with($adaptationSet->getTransientAttribute('mimeType'), 'audio/')){
+        if (!str_starts_with($adaptationSet->getTransientAttribute('mimeType'), 'audio/')) {
             return;
         }
         $signalledBrands = [];

--- a/app/Modules/CMAF/Segments/Durations.php
+++ b/app/Modules/CMAF/Segments/Durations.php
@@ -17,7 +17,7 @@ class Durations extends SegmentListComponent
             self::class,
             new ReporterContext(
                 "Segments",
-                "LEGACY",
+                "Edition 3",
                 "CMAF",
                 []
             )
@@ -35,11 +35,15 @@ class Durations extends SegmentListComponent
     public function validateSegmentList(Representation $representation, array $segments): void
     {
         //TODO: Version that works without sidx boxes
-        $currentOffset = 0;
+        $currentOffset = null;
 
         foreach ($segments as $segmentIndex => $segment) {
             $sidxBoxes = $segment->boxAccess()->sidx();
             $tfdtBoxes = $segment->boxAccess()->tfdt();
+
+            if ($currentOffset === null && count($tfdtBoxes) > 0){
+                $currentOffset = $tfdtBoxes[0]->decodeTime;
+            }
 
             $allReferences = [];
             foreach ($sidxBoxes as $sidxBox) {
@@ -58,6 +62,7 @@ class Durations extends SegmentListComponent
                 );
                 return;
             }
+
 
             $index = 0;
             $allValid = true;

--- a/app/Modules/CMAF/Segments/Durations.php
+++ b/app/Modules/CMAF/Segments/Durations.php
@@ -41,7 +41,7 @@ class Durations extends SegmentListComponent
             $sidxBoxes = $segment->boxAccess()->sidx();
             $tfdtBoxes = $segment->boxAccess()->tfdt();
 
-            if ($currentOffset === null && count($tfdtBoxes) > 0){
+            if ($currentOffset === null && count($tfdtBoxes) > 0) {
                 $currentOffset = $tfdtBoxes[0]->decodeTime;
             }
 

--- a/app/Modules/CMAF/Segments/VideoMediaProfile.php
+++ b/app/Modules/CMAF/Segments/VideoMediaProfile.php
@@ -52,7 +52,7 @@ class VideoMediaProfile extends AdaptationComponent
     //Public validation functions
     public function validateAdaptationSet(AdaptationSet $adaptationSet): void
     {
-        if (!str_starts_with($adaptationSet->getTransientAttribute('mimeType'), 'video/')){
+        if (!str_starts_with($adaptationSet->getTransientAttribute('mimeType'), 'video/')) {
             return;
         }
         $signalledBrands = [];

--- a/app/Modules/CMAF/Segments/VideoMediaProfile.php
+++ b/app/Modules/CMAF/Segments/VideoMediaProfile.php
@@ -52,7 +52,9 @@ class VideoMediaProfile extends AdaptationComponent
     //Public validation functions
     public function validateAdaptationSet(AdaptationSet $adaptationSet): void
     {
-       //TODO: Only if video
+        if (!str_starts_with($adaptationSet->getTransientAttribute('mimeType'), 'video/')){
+            return;
+        }
         $signalledBrands = [];
 
         $segmentManager = app(SegmentManager::class);


### PR DESCRIPTION
Contains various fixes for the CMAF segment analysis:

- BaseMediaDecodeTime is no longer required to be 0 for the first segment
- Video and Audio checks now only get run on their corresponding adaptation sets
- AAC object types now validate against the 'correct' field from the analyser output.